### PR TITLE
Legg til forsinket åpning av loggfil

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -23,7 +23,7 @@ def setup_logger(log_path: str = "bilagskontroll.log") -> logging.Logger:
     logger = logging.getLogger("bilagskontroll")
     if not logger.handlers:
         handler = RotatingFileHandler(
-            log_path, encoding="utf-8", maxBytes=1_000_000, backupCount=3
+            log_path, encoding="utf-8", maxBytes=1_000_000, backupCount=3, delay=True
         )
         handler.setFormatter(
             logging.Formatter("%(asctime)s %(levelname)s %(message)s")

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,21 @@
+import importlib
+import logging
+from pathlib import Path
+
+import helpers
+
+def test_logger_delayed_file_creation(tmp_path, monkeypatch):
+    logger = logging.getLogger("bilagskontroll")
+    for handler in logger.handlers[:]:
+        logger.removeHandler(handler)
+        handler.close()
+
+    monkeypatch.chdir(tmp_path)
+    module = importlib.reload(helpers)
+
+    log_file = Path(tmp_path) / "bilagskontroll.log"
+    assert not log_file.exists()
+
+    module.logger.info("første melding")
+    assert log_file.exists()
+    assert "første melding" in log_file.read_text(encoding="utf-8")


### PR DESCRIPTION
## Sammendrag
- Forsinket åpning av loggfil ved å bruke `delay=True` i `RotatingFileHandler`
- Lagt til test som sikrer at loggfil først opprettes når første melding logges

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b92dfdc7808328b7cab208fad2b65b