### PR TITLE
Gjør oppstart raskere

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -88,7 +88,7 @@ class App(ctk.CTk):
         self.bind("<Right>", lambda e: self.next())
         self.bind("<Control-o>", lambda e: self.open_in_po())
         self.render()
-        self._after_jobs.append(self.after(0, self.load_logo_images))
+        self._after_jobs.append(self.after_idle(self.load_logo_images))
         self._after_jobs.append(self.after_idle(self._init_dnd))
         self._after_jobs.append(self.after_idle(self._init_icon))
 

--- a/helpers.py
+++ b/helpers.py
@@ -33,7 +33,22 @@ def setup_logger(log_path: str = "bilagskontroll.log") -> logging.Logger:
     return logger
 
 
-logger = setup_logger()
+
+class _LazyLogger:
+    """Utsett opprettelsen av logger til første bruk."""
+
+    _logger = None
+
+    def _get(self):
+        if self._logger is None:
+            self._logger = setup_logger()
+        return self._logger
+
+    def __getattr__(self, name):
+        return getattr(self._get(), name)
+
+
+logger = _LazyLogger()
 
 def _pd():
     import pandas as pd


### PR DESCRIPTION
## Sammendrag
- Utsett opprettelsen av logger til den faktisk brukes for å unngå unødvendig arbeid ved oppstart.
- Last inn logo-bilder først når GUI-tråden er ledig, slik at vinduet vises raskere.

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b99a8dc04c8328aa482cb699563a42