### PR TITLE
Utsett tema-initialisering for raskere oppstart

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -6,19 +6,6 @@ import re
 
 # Tkinter og CustomTkinter importeres lazily for raskere oppstart.
 
-
-from helpers import (
-    resource_path,
-    to_str,
-    fmt_money,
-    format_number_with_thousands,
-    guess_invoice_col,
-    guess_col,
-    guess_net_amount_col,
-    fmt_pct,
-    logger,
-)
-
 APP_TITLE = "Bilagskontroll"
 OPEN_PO_URL = "https://go.poweroffice.net/#reports/purchases/invoice?"
 
@@ -31,14 +18,34 @@ class App:
 
         globals().update(tk=tk, ctk=ctk, filedialog=filedialog, messagebox=messagebox)
 
+        from helpers import (
+            resource_path,
+            to_str,
+            fmt_money,
+            format_number_with_thousands,
+            guess_invoice_col,
+            guess_col,
+            guess_net_amount_col,
+            fmt_pct,
+            logger,
+        )
+        globals().update(
+            resource_path=resource_path,
+            to_str=to_str,
+            fmt_money=fmt_money,
+            format_number_with_thousands=format_number_with_thousands,
+            guess_invoice_col=guess_invoice_col,
+            guess_col=guess_col,
+            guess_net_amount_col=guess_net_amount_col,
+            fmt_pct=fmt_pct,
+            logger=logger,
+        )
+
         self.__class__ = type(self.__class__.__name__, (ctk.CTk, self.__class__), {})
         ctk.CTk.__init__(self)
 
         self._dnd_ready = False
         self._icon_ready = False
-
-        ctk.set_appearance_mode("system")
-        ctk.set_default_color_theme("blue")
         self.title(APP_TITLE)
         self.geometry("1280x900")
         self.minsize(1180, 820)
@@ -68,6 +75,7 @@ class App:
 
         self.logo_img = None
         self._after_jobs = []
+        self._after_jobs.append(self.after_idle(self._init_theme))
 
         self.after(0, self._init_ui)
 
@@ -119,6 +127,10 @@ class App:
         self._icon_ready = True
 
     # Theme
+    def _init_theme(self):
+        ctk.set_appearance_mode("system")
+        ctk.set_default_color_theme("blue")
+
     def _switch_theme(self, mode):
         ctk.set_appearance_mode("light" if mode.lower()=="light" else "dark" if mode.lower()=="dark" else "system")
         if self._icon_ready:

--- a/gui/ledger.py
+++ b/gui/ledger.py
@@ -1,13 +1,10 @@
-import re
-import customtkinter as ctk
-from tkinter import ttk
-import tkinter.font as tkfont
-from helpers import to_str, only_digits, parse_amount, fmt_money
-
 LEDGER_COLS = ["Kontonr", "Konto", "Beskrivelse", "MVA", "MVA-beløp", "Beløp", "Postert av"]
 
 
 def apply_treeview_theme(app):
+    from tkinter import ttk
+    import customtkinter as ctk
+
     style = ttk.Style()
     try:
         style.theme_use("clam")
@@ -37,6 +34,8 @@ def apply_treeview_theme(app):
 
 
 def update_treeview_stripes(app):
+    import customtkinter as ctk
+
     mode = ctk.get_appearance_mode().lower()
     if mode == "dark":
         odd = "#232323"; even = "#1e1e1e"
@@ -48,6 +47,8 @@ def update_treeview_stripes(app):
 
 def sort_treeview(tree, col, reverse, app):
     """Sorter rader i ``tree`` etter valgt kolonne."""
+    from helpers import parse_amount
+
     data = []
     for iid in tree.get_children(""):
         cell = tree.set(iid, col)
@@ -66,6 +67,9 @@ def sort_treeview(tree, col, reverse, app):
 
 def ledger_rows(app, invoice_value: str):
     """Hent bilagslinjer for gitt bilagsnummer uten å endre ``gl_df``."""
+    import re
+    from helpers import to_str, only_digits, parse_amount, fmt_money
+
     if app.gl_df is None or app.gl_invoice_col not in (app.gl_df.columns if app.gl_df is not None else []):
         return []
     key = only_digits(invoice_value)
@@ -115,7 +119,9 @@ def ledger_rows(app, invoice_value: str):
     return rows
 
 
-def autofit_tree_columns(tree: ttk.Treeview, cols):
+def autofit_tree_columns(tree, cols):
+    import tkinter.font as tkfont
+
     body_font = tkfont.nametofont("TkDefaultFont")
     try:
         head_font = tkfont.nametofont("TkHeadingFont")
@@ -133,6 +139,8 @@ def autofit_tree_columns(tree: ttk.Treeview, cols):
 
 
 def populate_ledger_table(app, invoice_value: str):
+    from helpers import parse_amount, fmt_money
+
     for item in app.ledger_tree.get_children():
         app.ledger_tree.delete(item)
     rows = ledger_rows(app, invoice_value)

--- a/gui/mainview.py
+++ b/gui/mainview.py
@@ -1,15 +1,14 @@
-import tkinter as tk
-from tkinter import ttk
-import customtkinter as ctk
-from .ledger import (
-    LEDGER_COLS,
-    apply_treeview_theme,
-    update_treeview_stripes,
-    sort_treeview,
-)
-
-
 def build_main(app):
+    import tkinter as tk
+    from tkinter import ttk
+    import customtkinter as ctk
+    from .ledger import (
+        LEDGER_COLS,
+        apply_treeview_theme,
+        update_treeview_stripes,
+        sort_treeview,
+    )
+
     panel = ctk.CTkFrame(app, corner_radius=16)
     panel.grid(row=0, column=1, sticky="nsew", padx=(0, 14), pady=14)
     panel.grid_columnconfigure(0, weight=1)

--- a/gui/sidebar.py
+++ b/gui/sidebar.py
@@ -1,5 +1,4 @@
 import os
-import customtkinter as ctk
 
 
 def _toggle_sample_btn(app, *_):
@@ -8,6 +7,8 @@ def _toggle_sample_btn(app, *_):
 
 
 def build_sidebar(app):
+    import customtkinter as ctk
+
     card = ctk.CTkFrame(app, corner_radius=16)
     card.grid(row=0, column=0, sticky="nsw", padx=14, pady=14)
 


### PR DESCRIPTION
## Sammendrag
- Flytter CustomTkinter- og helper-importer inn i funksjoner og `__init__` for å unngå kostbare oppgaver ved oppstart.
- Sidebar og hovedpanel importerer nå CustomTkinter først når de bygges.
- Ledger-modulen laster egne avhengigheter kun når funksjonene faktisk kjøres.

## Testing
- `PYTHONPATH=$PWD pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b99efc37d48328b6362fa7bc1972f6