### PR TITLE
Utsett bygging av hoved-UI til etter event-loop

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -75,6 +75,10 @@ class App:
 
         self.logo_img = None
         self._init_theme()
+        self.after_idle(self._build_ui)
+
+    def _build_ui(self):
+        """Bygger hoved-UI etter at event-loopen er startet."""
         self._init_ui()
         self.after_idle(self._post_init)
 


### PR DESCRIPTION
## Sammendrag
- Utsetter bygging av hoved-UI til etter at event-loopen starter for raskere visning av rotvinduet.

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68baff47d050832891a1beb7d2973b4d