### PR TITLE
Sikker oppdatering av statuskort

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -484,7 +484,11 @@ class App:
             self.btn_prev.configure(state="normal" if self.idx > 0 else "disabled")
             self.btn_next.configure(state="normal" if self.idx < len(self.sample_df) - 1 else "disabled")
 
-        self._update_status_card_safe()
+        if (
+            (self.df is not None and len(self.df) > 0)
+            or (self.sample_df is not None and len(self.sample_df) > 0)
+        ):
+            self._update_status_card_safe()
 
 if __name__ == "__main__":
     App().mainloop()

--- a/tests/test_status_card.py
+++ b/tests/test_status_card.py
@@ -1,0 +1,52 @@
+import pandas as pd
+import gui
+from gui import App
+
+class DummyWidget:
+    def __init__(self):
+        self.cfg = {}
+    def configure(self, **kwargs):
+        self.cfg.update(kwargs)
+    def delete(self, *args, **kwargs):
+        pass
+    def insert(self, *args, **kwargs):
+        pass
+    def get_children(self):
+        return []
+
+class FakeApp:
+    def __init__(self):
+        self.df = pd.DataFrame({'Faktura':[1], 'Beløp':[100]})
+        self.sample_df = self.df.copy()
+        self.idx = 0
+        self.invoice_col = 'Faktura'
+        self.net_amount_col = 'Beløp'
+        self.decisions = [None]
+        self.comments = [None]
+        self.lbl_count = DummyWidget()
+        self.lbl_invoice = DummyWidget()
+        self.lbl_status = DummyWidget()
+        self.detail_box = DummyWidget()
+        self.ledger_tree = DummyWidget()
+        self.ledger_sum = DummyWidget()
+        self.comment_box = DummyWidget()
+        self.btn_prev = DummyWidget()
+        self.btn_next = DummyWidget()
+        self.status_card_called = False
+    def _ensure_helpers(self):
+        gui.to_str = str
+        gui.format_number_with_thousands = lambda x: x
+    def _update_counts_labels(self):
+        pass
+    def _current_row_dict(self):
+        return self.sample_df.iloc[self.idx].to_dict()
+    def _details_text_for_row(self, row_dict):
+        return ""
+    def _update_status_card_safe(self):
+        self.status_card_called = True
+
+
+def test_status_card_updates_after_sample():
+    app = FakeApp()
+    App.render(app)
+    assert app.status_card_called is True


### PR DESCRIPTION
## Endringer
- Oppdaterte `render` slik at statuskortet kun oppdateres når det finnes data.
- La til test som verifiserer at statuskortet oppdateres etter at et utvalg er generert.

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb1473066c8328aec2453ff599c3ca