### PR TITLE
Legg til create_button for enhetlig knappestil

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -13,6 +13,25 @@ OPEN_PO_URL = "https://go.poweroffice.net/#reports/purchases/invoice?"
 FONT_TITLE = None
 FONT_BODY = None
 
+# Standardstil for knapper
+BTN_FG = "#1f6aa5"
+BTN_HOVER = "#185a8b"
+BTN_RADIUS = 8
+
+
+def create_button(master, **kwargs):
+    """Opprett en knapp med felles stil."""
+    import customtkinter as ctk
+
+    options = {
+        "fg_color": BTN_FG,
+        "hover_color": BTN_HOVER,
+        "font": FONT_BODY,
+        "corner_radius": BTN_RADIUS,
+    }
+    options.update(kwargs)
+    return ctk.CTkButton(master, **options)
+
 # ----------------- App -----------------
 class App:
     def __init__(self):

--- a/gui/mainview.py
+++ b/gui/mainview.py
@@ -1,4 +1,4 @@
-from . import FONT_TITLE, FONT_BODY
+from . import FONT_TITLE, FONT_BODY, create_button
 
 
 def build_main(app):
@@ -29,7 +29,7 @@ def build_main(app):
     app.lbl_count.grid(row=0, column=0, padx=(4, 12))
     app.lbl_status.grid(row=0, column=1, padx=8)
     app.lbl_invoice.grid(row=0, column=2, padx=8)
-    ctk.CTkButton(head, text="📋 Kopier fakturanr", command=app.copy_invoice).grid(row=0, column=3, padx=(8,0))
+    create_button(head, text="📋 Kopier fakturanr", command=app.copy_invoice).grid(row=0, column=3, padx=(8,0))
     app.copy_feedback = ctk.CTkLabel(head, text="", text_color="#2ecc71")
     app.copy_feedback.grid(row=0, column=4, padx=8, sticky="w")
 
@@ -40,14 +40,14 @@ def build_main(app):
     btns.grid(row=1, column=0, sticky="ew", padx=12, pady=(0, 4))
     btns.grid_columnconfigure((0,1,2,3,4), weight=1)
 
-    ctk.CTkButton(btns, text="✅ Godkjent", fg_color="#2ecc71", hover_color="#29b765",
+    create_button(btns, text="✅ Godkjent", fg_color="#2ecc71", hover_color="#29b765",
                   command=lambda: app.set_decision_and_next("Godkjent")).grid(row=0, column=0, padx=6, pady=6, sticky="ew")
-    ctk.CTkButton(btns, text="⛔ Ikke godkjent", fg_color="#e74c3c", hover_color="#cf4334",
+    create_button(btns, text="⛔ Ikke godkjent", fg_color="#e74c3c", hover_color="#cf4334",
                   command=lambda: app.set_decision_and_next("Ikke godkjent")).grid(row=0, column=1, padx=6, pady=6, sticky="ew")
-    ctk.CTkButton(btns, text="🔗 Åpne i PowerOffice", command=app.open_in_po).grid(row=0, column=2, padx=6, pady=6, sticky="ew")
-    app.btn_prev = ctk.CTkButton(btns, text="⬅ Forrige", command=app.prev)
+    create_button(btns, text="🔗 Åpne i PowerOffice", command=app.open_in_po).grid(row=0, column=2, padx=6, pady=6, sticky="ew")
+    app.btn_prev = create_button(btns, text="⬅ Forrige", command=app.prev)
     app.btn_prev.grid(row=0, column=3, padx=6, pady=6, sticky="ew")
-    app.btn_next = ctk.CTkButton(btns, text="➡ Neste", command=app.next)
+    app.btn_next = create_button(btns, text="➡ Neste", command=app.next)
     app.btn_next.grid(row=0, column=4, padx=6, pady=6, sticky="ew")
 
     paned = ctk.CTkFrame(panel)
@@ -115,6 +115,6 @@ def build_main(app):
         from report import export_pdf
         export_pdf(app)
 
-    ctk.CTkButton(bottom, text="📄 Eksporter PDF rapport", command=_export_pdf).pack(side="left")
+    create_button(bottom, text="📄 Eksporter PDF rapport", command=_export_pdf).pack(side="left")
     ctk.CTkLabel(bottom, text="").pack(side="left", expand=True, fill="x")
     return panel

--- a/gui/sidebar.py
+++ b/gui/sidebar.py
@@ -1,5 +1,5 @@
 import os
-from . import FONT_TITLE, FONT_BODY
+from . import FONT_TITLE, FONT_BODY, create_button
 
 
 def _toggle_sample_btn(app, *_):
@@ -17,13 +17,13 @@ def build_sidebar(app):
         .grid(row=0, column=0, padx=14, pady=(14, 6), sticky="w")  # Spesiell font: stor tittel
 
     app.file_path_var = ctk.StringVar(master=app, value="")
-    ctk.CTkButton(card, text="Velg leverandørfakturaer (Excel)…", command=app.choose_file)\
+    create_button(card, text="Velg leverandørfakturaer (Excel)…", command=app.choose_file)\
         .grid(row=1, column=0, padx=14, pady=(4, 2), sticky="ew")
     ctk.CTkLabel(card, textvariable=app.file_path_var, wraplength=260, anchor="w", justify="left")\
         .grid(row=2, column=0, padx=14, pady=(0, 6), sticky="ew")
 
     app.gl_path_var = ctk.StringVar(master=app, value="")
-    ctk.CTkButton(card, text="Velg hovedbok (Excel)…", command=app.choose_gl_file)\
+    create_button(card, text="Velg hovedbok (Excel)…", command=app.choose_gl_file)\
         .grid(row=3, column=0, padx=14, pady=(2, 2), sticky="ew")
     ctk.CTkLabel(card, textvariable=app.gl_path_var, wraplength=260, anchor="w", justify="left")\
         .grid(row=4, column=0, padx=14, pady=(0, 6), sticky="ew")
@@ -66,7 +66,7 @@ def build_sidebar(app):
         validatecommand=(vcmd_year, "%P"),
     ).grid(row=1, column=1, padx=(8, 0), pady=(6, 0))
 
-    app.sample_btn = ctk.CTkButton(card, text="🎲 Lag utvalg", command=app.make_sample, state="disabled")
+    app.sample_btn = create_button(card, text="🎲 Lag utvalg", command=app.make_sample, state="disabled")
     app.sample_btn.grid(row=6, column=0, padx=14, pady=(8, 6), sticky="ew")
 
     app.sample_size_var.trace_add("write", lambda *_: _toggle_sample_btn(app))


### PR DESCRIPTION
## Sammendrag
- Opprettet `create_button` med felles farger, font og hjørneradius
- Tok i bruk `create_button` i `mainview` og `sidebar` for konsistente knapper

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bb14a60a488328b6411bd816367505