### PR TITLE
Initialiser dra-og-slipp ved første drop-forsøk

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -147,8 +147,8 @@ class App:
     def _post_init(self):
         self._init_theme()
         self.load_logo_images()
-        self._init_dnd()
         self._init_icon()
+        self.bind("<<Drop>>", self._lazy_init_dnd)
 
     def _init_dnd(self):
         TkinterDnD = getattr(self, "_TkinterDnD", None)
@@ -164,6 +164,13 @@ class App:
         self.drop_target_register("DND_Files")
         self.dnd_bind("<<Drop>>", self._on_drop)
         self._dnd_ready = True
+
+    def _lazy_init_dnd(self, event):
+        if not getattr(self, "_dnd_ready", False):
+            self.unbind("<<Drop>>")
+            self._init_dnd()
+        if self._dnd_ready:
+            self._on_drop(event)
 
     def _init_icon(self):
         self._update_icon()


### PR DESCRIPTION
## Oppsummering
- Fjerner tidlig kall til `_init_dnd` og legger til binding for `<<Drop>>` som utløser initiering ved første drop
- Legger til `_lazy_init_dnd` som initierer dra-og-slipp og videresender hendelsen

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb180640c08328b2de1f7aa8aac938