### PR TITLE
Utsett tema-, logo- og ikoninitiering

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -145,10 +145,10 @@ class App:
         self.protocol("WM_DELETE_WINDOW", self.destroy)
 
     def _post_init(self):
-        self._init_theme()
-        self.load_logo_images()
+        self.after(200, self._init_theme)
+        self.after(200, self.load_logo_images)
         self._init_dnd()
-        self._init_icon()
+        self.after(200, self._init_icon)
 
     def _init_dnd(self):
         TkinterDnD = getattr(self, "_TkinterDnD", None)


### PR DESCRIPTION
## Oppsummering
- Utsetter tema-, logo- og ikoninitialisering med `after` for raskere oppstart.

## Testing
- `python -m pytest -q`
- `python - <<'PY' from gui import App; app=App(); app.after(100, app.destroy); app.mainloop(); PY` *(feiler: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb1bebcf04832895b24bdcb230b362