### PR TITLE
Dokumenter automatisk opprettelse av loggkatalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## 1.0.4
+
+### Endringer
+- Loggeren oppretter automatisk katalogen for loggfilen.
+
+### Dokumentasjon
+- README oppdatert med informasjon om logging.
+
 ## 1.0.3
 
 ### Endringer

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Programmet er skrevet i Python og bruker `pandas` til å lese og filtrere Excel�
 - Deaktiverer navigasjonsknappene ved første og siste bilag for å hindre ugyldig navigering
 - Validerer tallfelt i grensesnittet for å sikre gyldige inputverdier
 - PDF‑rapporten viser tidspunkt for når den ble generert
+- Logger hendelser til fil og oppretter loggkatalogen automatisk ved behov
 
 ## Avhengigheter
 


### PR DESCRIPTION
## Sammendrag
- beskriv loggingen som nå oppretter loggkatalogen automatisk
- legg til versjonsnotat for 1.0.4 med denne endringen

## Testing
- `PYTHONPATH=$PWD pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb1f4fef708328abb540c1131be447