### PR TITLE
Kontroll av summeringsrad i calc_sum_net_all

### DIFF
--- a/data_utils.py
+++ b/data_utils.py
@@ -109,12 +109,18 @@ def calc_sum_kontrollert(sample_df: Optional[pd.DataFrame], decisions: list, net
     return total
 
 
-def calc_sum_net_all(df: Optional[pd.DataFrame], net_amount_col: Optional[str]) -> float:
+def calc_sum_net_all(
+    df: Optional[pd.DataFrame],
+    net_amount_col: Optional[str],
+    skip_last: bool = True,
+) -> float:
     if df is None or df.dropna(how="all").empty:
         return 0.0
     df_eff = df.dropna(how="all").copy()
-    if len(df_eff) > 0:
-        df_eff = df_eff.iloc[:-1]
+    if skip_last and len(df_eff) > 0:
+        last_row = df_eff.iloc[-1].astype(str)
+        if last_row.str.contains(r"\bsum\b", case=False).any():
+            df_eff = df_eff.iloc[:-1]
     mask = ~df_eff.astype(str).apply(lambda c: c.str.contains(r"\bsum\b", case=False)).any(axis=1)
     df_eff = df_eff.loc[mask]
     total = 0.0

--- a/tests/test_calc_sum_net_all.py
+++ b/tests/test_calc_sum_net_all.py
@@ -24,3 +24,11 @@ def test_calc_sum_net_all_kun_summeringsrad():
         'netto': [123.0]
     })
     assert calc_sum_net_all(df, 'netto') == 0.0
+
+
+def test_calc_sum_net_all_beholder_siste_rad_uten_sum():
+    df = pd.DataFrame({
+        'tekst': ['rad1', 'rad2', 'rad3'],
+        'netto': [100.0, 200.0, 300.0]
+    })
+    assert calc_sum_net_all(df, 'netto') == 600.0


### PR DESCRIPTION
## Sammendrag
- legg til valgfritt `skip_last`-flagg som kun fjerner siste rad hvis den inneholder `sum`
- utvid tester for å sikre at ikke-summeringsrader beholdes

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb22eb913c8328a67d01e22a1bf8f0