### PR TITLE
Legg til fargestruktur for tema

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -19,6 +19,26 @@ BTN_HOVER = "#185a8b"
 BTN_RADIUS = 8
 
 
+# Farger per tema
+COLORS = {
+    "success": {"light": "#2ecc71", "dark": "#27ae60"},
+    "success_hover": {"light": "#29b765", "dark": "#219150"},
+    "error": {"light": "#e74c3c", "dark": "#c0392b"},
+    "error_hover": {"light": "#cf4334", "dark": "#992d22"},
+}
+
+
+def get_color(name: str) -> str:
+    """Returner farge basert på gjeldende tema."""
+    import customtkinter as ctk
+
+    mode = ctk.get_appearance_mode().lower()
+    try:
+        return COLORS[name]["dark" if mode == "dark" else "light"]
+    except KeyError as e:
+        raise KeyError(f"Ukjent fargenavn: {name}") from e
+
+
 def create_button(master, **kwargs):
     """Opprett en knapp med felles stil."""
     import customtkinter as ctk
@@ -447,7 +467,9 @@ class App:
     # PDF
     # Inline
     def _show_inline(self, msg: str, ok=True):
-        self.inline_status.configure(text_color=("#2ecc71" if ok else "#e74c3c"))
+        self.inline_status.configure(
+            text_color=(get_color("success") if ok else get_color("error"))
+        )
         self.inline_status.configure(text=msg)
         self.after(3500, lambda: self.inline_status.configure(text=""))
 

--- a/gui/mainview.py
+++ b/gui/mainview.py
@@ -1,4 +1,4 @@
-from . import FONT_TITLE, FONT_BODY, create_button
+from . import FONT_TITLE, FONT_BODY, create_button, get_color
 
 
 def build_main(app):
@@ -30,20 +30,30 @@ def build_main(app):
     app.lbl_status.grid(row=0, column=1, padx=8)
     app.lbl_invoice.grid(row=0, column=2, padx=8)
     create_button(head, text="📋 Kopier fakturanr", command=app.copy_invoice).grid(row=0, column=3, padx=(8,0))
-    app.copy_feedback = ctk.CTkLabel(head, text="", text_color="#2ecc71")
+    app.copy_feedback = ctk.CTkLabel(head, text="", text_color=get_color("success"))
     app.copy_feedback.grid(row=0, column=4, padx=8, sticky="w")
 
-    app.inline_status = ctk.CTkLabel(head, text="", text_color="#2ecc71")
+    app.inline_status = ctk.CTkLabel(head, text="", text_color=get_color("success"))
     app.inline_status.grid(row=0, column=5, padx=8, sticky="e")
 
     btns = ctk.CTkFrame(panel)
     btns.grid(row=1, column=0, sticky="ew", padx=12, pady=(0, 4))
     btns.grid_columnconfigure((0,1,2,3,4), weight=1)
 
-    create_button(btns, text="✅ Godkjent", fg_color="#2ecc71", hover_color="#29b765",
-                  command=lambda: app.set_decision_and_next("Godkjent")).grid(row=0, column=0, padx=6, pady=6, sticky="ew")
-    create_button(btns, text="⛔ Ikke godkjent", fg_color="#e74c3c", hover_color="#cf4334",
-                  command=lambda: app.set_decision_and_next("Ikke godkjent")).grid(row=0, column=1, padx=6, pady=6, sticky="ew")
+    create_button(
+        btns,
+        text="✅ Godkjent",
+        fg_color=get_color("success"),
+        hover_color=get_color("success_hover"),
+        command=lambda: app.set_decision_and_next("Godkjent"),
+    ).grid(row=0, column=0, padx=6, pady=6, sticky="ew")
+    create_button(
+        btns,
+        text="⛔ Ikke godkjent",
+        fg_color=get_color("error"),
+        hover_color=get_color("error_hover"),
+        command=lambda: app.set_decision_and_next("Ikke godkjent"),
+    ).grid(row=0, column=1, padx=6, pady=6, sticky="ew")
     create_button(btns, text="🔗 Åpne i PowerOffice", command=app.open_in_po).grid(row=0, column=2, padx=6, pady=6, sticky="ew")
     app.btn_prev = create_button(btns, text="⬅ Forrige", command=app.prev)
     app.btn_prev.grid(row=0, column=3, padx=6, pady=6, sticky="ew")


### PR DESCRIPTION
## Sammendrag
- Introducerer `COLORS` og `get_color` for temabaserte farger
- Bruker `get_color` i hovedvisning og inline-varsler

## Testing
- `PYTHONPATH=. pytest -q`
- `xvfb-run -a python - <<'PY'
from gui import App
import customtkinter as ctk
app = App()
app.update()
app._switch_theme('Light')
app._switch_theme('Dark')
print('Theme switch done')
app.destroy()
PY`

------
https://chatgpt.com/codex/tasks/task_e_68bbe11d0a948328bcbc26ff2a9447e8