### PR TITLE
Bruk delte fontkonstanter i GUI

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -12,6 +12,12 @@ OPEN_PO_URL = "https://go.poweroffice.net/#reports/purchases/invoice?"
 # Delte skrifttyper
 FONT_TITLE = None
 FONT_BODY = None
+FONT_TITLE_LITE = None
+FONT_TITLE_LARGE = None
+FONT_TITLE_SMALL = None
+FONT_BODY_BOLD = None
+FONT_SMALL = None
+FONT_SMALL_ITALIC = None
 
 # Standardstil for knapper
 BTN_FG = "#1f6aa5"
@@ -101,11 +107,24 @@ class App:
         self.after_idle(self._build_ui)
 
     def _init_fonts(self):
-        global FONT_TITLE, FONT_BODY
+        global FONT_TITLE, FONT_BODY, FONT_TITLE_LITE, FONT_TITLE_LARGE, FONT_TITLE_SMALL, \
+            FONT_BODY_BOLD, FONT_SMALL, FONT_SMALL_ITALIC
         if FONT_TITLE is None:
             FONT_TITLE = ctk.CTkFont(size=16, weight="bold")
         if FONT_BODY is None:
             FONT_BODY = ctk.CTkFont(size=14)
+        if FONT_TITLE_LITE is None:
+            FONT_TITLE_LITE = ctk.CTkFont(size=16)
+        if FONT_TITLE_LARGE is None:
+            FONT_TITLE_LARGE = ctk.CTkFont(size=18, weight="bold")
+        if FONT_TITLE_SMALL is None:
+            FONT_TITLE_SMALL = ctk.CTkFont(size=15, weight="bold")
+        if FONT_BODY_BOLD is None:
+            FONT_BODY_BOLD = ctk.CTkFont(size=14, weight="bold")
+        if FONT_SMALL is None:
+            FONT_SMALL = ctk.CTkFont(size=13)
+        if FONT_SMALL_ITALIC is None:
+            FONT_SMALL_ITALIC = ctk.CTkFont(size=12, slant="italic")
 
     def _ensure_helpers(self):
         """Importer tunge hjelpefunksjoner fra ``helpers`` ved første behov."""

--- a/gui/mainview.py
+++ b/gui/mainview.py
@@ -1,4 +1,12 @@
-from . import FONT_TITLE, FONT_BODY, create_button, get_color
+from . import (
+    FONT_TITLE,
+    FONT_BODY,
+    FONT_TITLE_LITE,
+    FONT_TITLE_SMALL,
+    FONT_SMALL,
+    create_button,
+    get_color,
+)
 
 
 def build_main(app):
@@ -20,8 +28,7 @@ def build_main(app):
     head.grid(row=0, column=0, sticky="ew", padx=12, pady=8)
     head.grid_columnconfigure(6, weight=1)
 
-    # Spesiell font: større uten fet skrift
-    head_font = ctk.CTkFont(size=16)
+    head_font = FONT_TITLE_LITE
 
     app.lbl_count = ctk.CTkLabel(head, text="Bilag: –/–", font=FONT_TITLE)
     app.lbl_status = ctk.CTkLabel(head, text="Status: –", font=head_font)
@@ -70,15 +77,15 @@ def build_main(app):
     left.grid(row=0, column=0, sticky="nsew")
     right.grid(row=0, column=1, sticky="nsew")
 
-    ctk.CTkLabel(left, text="Detaljer for bilag", font=ctk.CTkFont(size=15, weight="bold"))\
-        .grid(row=0, column=0, sticky="w", padx=8, pady=(4,4))  # Spesiell font: 15pt tittel
+    ctk.CTkLabel(left, text="Detaljer for bilag", font=FONT_TITLE_SMALL)\
+        .grid(row=0, column=0, sticky="w", padx=8, pady=(4,4))
     left.grid_columnconfigure(0, weight=1)
     left.grid_rowconfigure(1, weight=1, minsize=120)
     app.detail_box = ctk.CTkTextbox(left, height=360, font=FONT_BODY)
     app.detail_box.grid(row=1, column=0, sticky="nsew", padx=(8,6), pady=(0,8))
 
-    ctk.CTkLabel(right, text="Hovedbok (bilagslinjer)", font=ctk.CTkFont(size=15, weight="bold"))\
-        .grid(row=0, column=0, sticky="w", padx=8, pady=(4,4))  # Spesiell font: 15pt tittel
+    ctk.CTkLabel(right, text="Hovedbok (bilagslinjer)", font=FONT_TITLE_SMALL)\
+        .grid(row=0, column=0, sticky="w", padx=8, pady=(4,4))
     right.grid_columnconfigure(0, weight=1)
     right.grid_columnconfigure(1, weight=0)
     right.grid_rowconfigure(1, weight=3, minsize=150)
@@ -112,9 +119,9 @@ def build_main(app):
     app.ledger_sum = ctk.CTkLabel(right, text=" ", anchor="e", justify="right")
     app.ledger_sum.grid(row=3, column=0, columnspan=2, sticky="ew", padx=(0, 12), pady=(6, 10))
 
-    ctk.CTkLabel(right, text="Kommentar", font=ctk.CTkFont(size=15, weight="bold"))\
-        .grid(row=4, column=0, columnspan=2, sticky="w", padx=(8, 6), pady=(8, 4))  # Spesiell font: 15pt tittel
-    app.comment_box = ctk.CTkTextbox(right, height=110, font=ctk.CTkFont(size=13))  # Spesiell liten font
+    ctk.CTkLabel(right, text="Kommentar", font=FONT_TITLE_SMALL)\
+        .grid(row=4, column=0, columnspan=2, sticky="w", padx=(8, 6), pady=(8, 4))
+    app.comment_box = ctk.CTkTextbox(right, height=110, font=FONT_SMALL)
     app.comment_box.grid(row=5, column=0, columnspan=2, sticky="nsew", padx=(8, 6), pady=(0, 0))
 
     bottom = ctk.CTkFrame(panel)

--- a/gui/sidebar.py
+++ b/gui/sidebar.py
@@ -1,5 +1,13 @@
 import os
-from . import FONT_TITLE, FONT_BODY, create_button
+from . import (
+    FONT_TITLE,
+    FONT_BODY,
+    FONT_TITLE_LARGE,
+    FONT_BODY_BOLD,
+    FONT_SMALL,
+    FONT_SMALL_ITALIC,
+    create_button,
+)
 
 
 def _toggle_sample_btn(app, *_):
@@ -13,8 +21,8 @@ def build_sidebar(app):
     card = ctk.CTkFrame(app, corner_radius=16)
     card.grid(row=0, column=0, sticky="nsw", padx=14, pady=14)
 
-    ctk.CTkLabel(card, text="⚙️ Innstillinger", font=ctk.CTkFont(size=18, weight="bold"))\
-        .grid(row=0, column=0, padx=14, pady=(14, 6), sticky="w")  # Spesiell font: stor tittel
+    ctk.CTkLabel(card, text="⚙️ Innstillinger", font=FONT_TITLE_LARGE)\
+        .grid(row=0, column=0, padx=14, pady=(14, 6), sticky="w")
 
     app.file_path_var = ctk.StringVar(master=app, value="")
     create_button(card, text="Velg leverandørfakturaer (Excel)…", command=app.choose_file)\
@@ -75,8 +83,8 @@ def build_sidebar(app):
     app.lbl_filecount = ctk.CTkLabel(card, text="Antall bilag: –", font=FONT_TITLE)
     app.lbl_filecount.grid(row=7, column=0, padx=14, pady=(2, 2), sticky="w")
 
-    ctk.CTkLabel(card, text="Oppdragsinfo", font=ctk.CTkFont(size=14, weight="bold"))\
-        .grid(row=8, column=0, padx=14, pady=(8, 2), sticky="w")  # Spesiell font: 14pt fet
+    ctk.CTkLabel(card, text="Oppdragsinfo", font=FONT_BODY_BOLD)\
+        .grid(row=8, column=0, padx=14, pady=(8, 2), sticky="w")
     opp = ctk.CTkFrame(card, corner_radius=8)
     opp.grid(row=9, column=0, padx=14, pady=(0, 8), sticky="ew")
     opp.grid_columnconfigure(0, weight=0)
@@ -105,7 +113,7 @@ def build_sidebar(app):
     info_lbl = ctk.CTkLabel(
         opp,
         text="Kundenavn hentes automatisk",
-        font=ctk.CTkFont(size=12, slant="italic"),  # Spesiell font: liten og kursiv
+        font=FONT_SMALL_ITALIC,
         anchor="w",
         justify="left",
         wraplength=240,
@@ -114,8 +122,8 @@ def build_sidebar(app):
 
     card.grid_rowconfigure(20, weight=1)
 
-    ctk.CTkLabel(card, text="Tema", font=ctk.CTkFont(size=13))\
-        .grid(row=101, column=0, padx=14, pady=(0, 0), sticky="w")  # Spesiell font: 13pt
+    ctk.CTkLabel(card, text="Tema", font=FONT_SMALL)\
+        .grid(row=101, column=0, padx=14, pady=(0, 0), sticky="w")
     theme = ctk.CTkSegmentedButton(card, values=["System", "Light", "Dark"], command=app._switch_theme)
     theme.set("System")
     theme.grid(row=102, column=0, padx=14, pady=(2, 14), sticky="ew")
@@ -124,7 +132,7 @@ def build_sidebar(app):
     status_card.grid(row=100, column=0, padx=14, pady=(8, 14), sticky="ew")
     status_card.grid_columnconfigure(0, weight=1)
 
-    title_font = ctk.CTkFont(size=18, weight="bold")  # Spesiell font: større enn vanlig tittel
+    title_font = FONT_TITLE_LARGE
     body_font = FONT_BODY
 
     ctk.CTkLabel(status_card, text="Status", font=title_font, anchor="center", justify="center")\


### PR DESCRIPTION
## Oppsummering
- Definerer flere delte skrifttyper i `gui/__init__.py`
- Erstatter direkte `CTkFont`-kall i `mainview` og `sidebar`
- Sørger for at `App._init_fonts` initialiserer alle skrifttyper

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bbe3b6ead883289d8232d04be3ccea