### PR TITLE
Refaktor tema-bytter med oppslagskart

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -218,7 +218,8 @@ class App:
 
     def _switch_theme(self, mode):
         self._init_theme()
-        ctk.set_appearance_mode("light" if mode.lower()=="light" else "dark" if mode.lower()=="dark" else "system")
+        modes = {"light": "light", "dark": "dark"}
+        ctk.set_appearance_mode(modes.get(mode.lower(), "system"))
         if self._icon_ready:
             self._update_icon()
         from .ledger import apply_treeview_theme, update_treeview_stripes


### PR DESCRIPTION
## Oppsummering
- Erstattet ternært uttrykk i `_switch_theme` med oppslagskart for lys/mørk modus
- Beholdt oppdatering av ikon og tema etter bytte

## Testing
- `PYTHONPATH=$PWD pytest -q`
- `python - <<'PY'
import customtkinter as ctk
from gui import App
app = App()
app._switch_theme('light')
print('mode after light', ctk.get_appearance_mode())
app._switch_theme('dark')
print('mode after dark', ctk.get_appearance_mode())
app.destroy()
PY` *(feil: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68bbe60c6dbc8328931b540f3b79f764