### PR TITLE
Tilpass vindusstørrelse til skjermen

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -76,8 +76,16 @@ class App:
         self._dnd_ready = False
         self._icon_ready = False
         self.title(APP_TITLE)
-        self.geometry("1280x900")
-        self.minsize(1180, 820)
+
+        screen_w = self.winfo_screenwidth()
+        screen_h = self.winfo_screenheight()
+        width = int(screen_w * 0.8)
+        height = int(screen_h * 0.8)
+        self.geometry(f"{width}x{height}")
+        min_w = int(screen_w * 0.6)
+        min_h = int(screen_h * 0.6)
+        self.minsize(min_w, min_h)
+
         self.app_icon_img = None
 
         self.df = None


### PR DESCRIPTION
## Sammendrag
- Hent skjermbreidde og -høgd frå tkinter og bruk desse til å setje startgeometrien til 80 % av skjermen.
- Set minimumsstorleik dynamisk til 60 % av skjermstorleiken.

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbfae3c42883289a0369997542ee90