### PR TITLE
Juster vinduhøyde for tema-boksen

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -80,10 +80,10 @@ class App:
         screen_w = self.winfo_screenwidth()
         screen_h = self.winfo_screenheight()
         width = int(screen_w * 0.8)
-        height = int(screen_h * 0.8)
+        height = int(screen_h * 0.9)
         self.geometry(f"{width}x{height}")
         min_w = int(screen_w * 0.6)
-        min_h = int(screen_h * 0.6)
+        min_h = int(screen_h * 0.7)
         self.minsize(min_w, min_h)
 
         self.app_icon_img = None


### PR DESCRIPTION
## Oppsummering
- Øker standardhøyde til 90% av skjermhøyden og minimumshøyde til 70% for å vise bunnpanelet.

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc3c799e888328b3bbed0cdd21d876