### PR TITLE
Bruk pyarrow som Excel-motor når tilgjengelig

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,14 @@ Programmet er skrevet i Python og bruker `pandas` til å lese og filtrere Excel�
 - [pandas](https://pypi.org/project/pandas/) – leser og håndterer Excel‑data
 - [customtkinter](https://pypi.org/project/customtkinter/) – gir et moderne brukergrensesnitt
 - [reportlab](https://pypi.org/project/reportlab/) – genererer PDF‑rapporten
+- [pyarrow](https://pypi.org/project/pyarrow/) – raskere Excel‑innlasting (valgfritt)
 
 ## Installasjon
 
 ```bash
 python -m venv venv
 source venv/bin/activate  # venv\Scripts\activate på Windows
-pip install pandas customtkinter reportlab
+pip install pandas customtkinter reportlab pyarrow
 ```
 
 ## Bruk

--- a/README.md
+++ b/README.md
@@ -37,14 +37,14 @@ Programmet er skrevet i Python og bruker `pandas` til å lese og filtrere Excel�
 - [pandas](https://pypi.org/project/pandas/) – leser og håndterer Excel‑data
 - [customtkinter](https://pypi.org/project/customtkinter/) – gir et moderne brukergrensesnitt
 - [reportlab](https://pypi.org/project/reportlab/) – genererer PDF‑rapporten
-- [pyarrow](https://pypi.org/project/pyarrow/) – raskere Excel‑innlasting (valgfritt)
+- [pyarrow](https://pypi.org/project/pyarrow/) – raskere Excel‑innlasting (valgfritt, krever pandas >= 2.0)
 
 ## Installasjon
 
 ```bash
 python -m venv venv
 source venv/bin/activate  # venv\Scripts\activate på Windows
-pip install pandas customtkinter reportlab pyarrow
+pip install "pandas>=2.0" customtkinter reportlab pyarrow
 ```
 
 ## Bruk

--- a/data_utils.py
+++ b/data_utils.py
@@ -23,13 +23,22 @@ def _pd():
 
 
 def _excel_engine() -> str:
-    """Velg raskeste tilgjengelige Excel-motor."""
-    try:  # Foretrekk pyarrow hvis installert
-        import pyarrow  # type: ignore  # noqa: F401
+    """Velg raskeste tilgjengelige Excel-motor.
 
-        return "pyarrow"
+    Bruk ``pyarrow`` når både biblioteket og støtte i ``pandas`` (>=2.0) er
+    tilgjengelig. Ellers fall tilbake til ``openpyxl``.
+    """
+
+    try:
+        import importlib
+        import pandas as pd
+        importlib.import_module("pyarrow")
+        major, minor = (int(x) for x in pd.__version__.split(".")[:2])
+        if (major, minor) >= (2, 0):
+            return "pyarrow"
     except Exception:
-        return "openpyxl"
+        pass
+    return "openpyxl"
 
 
 def load_invoice_df(path: str, header_idx: int = 4) -> pd.DataFrame:

--- a/data_utils.py
+++ b/data_utils.py
@@ -22,20 +22,32 @@ def _pd():
     return pd
 
 
+def _excel_engine() -> str:
+    """Velg raskeste tilgjengelige Excel-motor."""
+    try:  # Foretrekk pyarrow hvis installert
+        import pyarrow  # type: ignore  # noqa: F401
+
+        return "pyarrow"
+    except Exception:
+        return "openpyxl"
+
+
 def load_invoice_df(path: str, header_idx: int = 4) -> pd.DataFrame:
     """Leser fakturalisten fra Excel."""
     logger.info(f"Laster fakturaliste fra {path}")
     pd = _pd()
-    return pd.read_excel(path, engine="openpyxl", header=header_idx)
+    engine = _excel_engine()
+    return pd.read_excel(path, engine=engine, header=header_idx)
 
 
 def load_gl_df(path: str) -> pd.DataFrame:
     """Leser hovedboken fra Excel."""
     logger.info(f"Laster hovedbok fra {path}")
     pd = _pd()
-    gl = pd.read_excel(path, engine="openpyxl", header=0)
+    engine = _excel_engine()
+    gl = pd.read_excel(path, engine=engine, header=0)
     if sum(str(c).lower().startswith("unnamed") for c in gl.columns) > len(gl.columns) / 2:
-        gl = pd.read_excel(path, engine="openpyxl", header=4)
+        gl = pd.read_excel(path, engine=engine, header=4)
     return gl
 
 
@@ -50,7 +62,8 @@ def extract_customer_from_invoice_file(path: str) -> Optional[str]:
     logger.info(f"Henter kundenavn fra {path}")
     try:
         pd = _pd()
-        raw = pd.read_excel(path, engine="openpyxl", header=None, nrows=2)
+        engine = _excel_engine()
+        raw = pd.read_excel(path, engine=engine, header=None, nrows=2)
     except Exception:
         return None
     if raw is None or len(raw) < 2:


### PR DESCRIPTION
## Sammendrag
- Legg til hjelpefunksjon som velger pyarrow som Excel-motor hvis installert, ellers openpyxl
- Bruk den nye funksjonen i opplasting av faktura, hovedbok og kundenavn
- Dokumenter pyarrow som valgfri avhengighet og oppdater installasjonsinstruksjoner

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc5fc52cf08328af7c53fc92159ab0