### PR TITLE
Bruk openpyxl for å finne header i load_gl_df

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))

--- a/tests/test_load_gl_df.py
+++ b/tests/test_load_gl_df.py
@@ -1,0 +1,27 @@
+from openpyxl import Workbook
+
+from data_utils import load_gl_df
+
+
+def _write_gl(path, header_row):
+    wb = Workbook()
+    ws = wb.active
+    for _ in range(header_row - 1):
+        ws.append([])
+    ws.append(["A", "B"])
+    ws.append([1, 2])
+    wb.save(path)
+
+
+def test_load_gl_df_detects_header(tmp_path):
+    # Header på første rad
+    path1 = tmp_path / "gl1.xlsx"
+    _write_gl(path1, header_row=1)
+    df1 = load_gl_df(str(path1))
+    assert list(df1.columns) == ["A", "B"]
+
+    # Header etter fire tomme rader
+    path2 = tmp_path / "gl2.xlsx"
+    _write_gl(path2, header_row=5)
+    df2 = load_gl_df(str(path2))
+    assert list(df2.columns) == ["A", "B"]


### PR DESCRIPTION
## Oppsummering
- Bestemmer nå kolonneheader i `load_gl_df` ved å lese de første radene med openpyxl og leser deretter filen kun én gang med pandas
- La til tester for å sikre at header oppdages både når den ligger på første rad og etter tomme rader
- La til testoppsett for å gjøre modulene tilgjengelige under testing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc66b501ac83289e86ac749de90653