### PR TITLE
Flytt felles stil til egen modul

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -21,30 +21,7 @@ def _ctk():
 
 APP_TITLE = "Bilagskontroll"
 OPEN_PO_URL = "https://go.poweroffice.net/#reports/purchases/invoice?"
-
-# Delte skrifttyper
-FONT_TITLE = None
-FONT_BODY = None
-FONT_TITLE_LITE = None
-FONT_TITLE_LARGE = None
-FONT_TITLE_SMALL = None
-FONT_BODY_BOLD = None
-FONT_SMALL = None
-FONT_SMALL_ITALIC = None
-
-# Standardstil for knapper
-BTN_FG = "#1f6aa5"
-BTN_HOVER = "#185a8b"
-BTN_RADIUS = 8
-
-
-# Farger per tema
-COLORS = {
-    "success": {"light": "#2ecc71", "dark": "#27ae60"},
-    "success_hover": {"light": "#29b765", "dark": "#219150"},
-    "error": {"light": "#e74c3c", "dark": "#c0392b"},
-    "error_hover": {"light": "#cf4334", "dark": "#992d22"},
-}
+from .style import style
 
 
 def get_color(name: str) -> str:
@@ -53,7 +30,7 @@ def get_color(name: str) -> str:
 
     mode = ctk.get_appearance_mode().lower()
     try:
-        return COLORS[name]["dark" if mode == "dark" else "light"]
+        return style.colors.palette[name]["dark" if mode == "dark" else "light"]
     except KeyError as e:
         raise KeyError(f"Ukjent fargenavn: {name}") from e
 
@@ -63,10 +40,10 @@ def create_button(master, **kwargs):
     ctk = _ctk()
 
     options = {
-        "fg_color": BTN_FG,
-        "hover_color": BTN_HOVER,
-        "font": FONT_BODY,
-        "corner_radius": BTN_RADIUS,
+        "fg_color": style.colors.btn_fg,
+        "hover_color": style.colors.btn_hover,
+        "font": style.fonts.body,
+        "corner_radius": style.colors.btn_radius,
     }
     options.update(kwargs)
     return ctk.CTkButton(master, **options)
@@ -147,24 +124,23 @@ class App:
 
     def _init_fonts(self):
         ctk = _ctk()
-        global FONT_TITLE, FONT_BODY, FONT_TITLE_LITE, FONT_TITLE_LARGE, FONT_TITLE_SMALL, \
-            FONT_BODY_BOLD, FONT_SMALL, FONT_SMALL_ITALIC
-        if FONT_TITLE is None:
-            FONT_TITLE = ctk.CTkFont(size=16, weight="bold")
-        if FONT_BODY is None:
-            FONT_BODY = ctk.CTkFont(size=14)
-        if FONT_TITLE_LITE is None:
-            FONT_TITLE_LITE = ctk.CTkFont(size=16)
-        if FONT_TITLE_LARGE is None:
-            FONT_TITLE_LARGE = ctk.CTkFont(size=18, weight="bold")
-        if FONT_TITLE_SMALL is None:
-            FONT_TITLE_SMALL = ctk.CTkFont(size=15, weight="bold")
-        if FONT_BODY_BOLD is None:
-            FONT_BODY_BOLD = ctk.CTkFont(size=14, weight="bold")
-        if FONT_SMALL is None:
-            FONT_SMALL = ctk.CTkFont(size=13)
-        if FONT_SMALL_ITALIC is None:
-            FONT_SMALL_ITALIC = ctk.CTkFont(size=12, slant="italic")
+        fonts = style.fonts
+        if fonts.title is None:
+            fonts.title = ctk.CTkFont(size=16, weight="bold")
+        if fonts.body is None:
+            fonts.body = ctk.CTkFont(size=14)
+        if fonts.title_lite is None:
+            fonts.title_lite = ctk.CTkFont(size=16)
+        if fonts.title_large is None:
+            fonts.title_large = ctk.CTkFont(size=18, weight="bold")
+        if fonts.title_small is None:
+            fonts.title_small = ctk.CTkFont(size=15, weight="bold")
+        if fonts.body_bold is None:
+            fonts.body_bold = ctk.CTkFont(size=14, weight="bold")
+        if fonts.small is None:
+            fonts.small = ctk.CTkFont(size=13)
+        if fonts.small_italic is None:
+            fonts.small_italic = ctk.CTkFont(size=12, slant="italic")
 
     def _ensure_helpers(self):
         """Importer tunge hjelpefunksjoner fra ``helpers`` ved første behov."""

--- a/gui/mainview.py
+++ b/gui/mainview.py
@@ -18,22 +18,24 @@ def build_main(app):
 
     head = ctk.CTkFrame(panel)
     head.grid(row=0, column=0, sticky="ew", padx=12, pady=8)
-    head.grid_columnconfigure(6, weight=1)
+    head.grid_columnconfigure(7, weight=1)
 
     head_font = style.fonts.title_lite
 
     app.lbl_count = ctk.CTkLabel(head, text="Bilag: –/–", font=style.fonts.title)
     app.lbl_status = ctk.CTkLabel(head, text="Status: –", font=head_font)
     app.lbl_invoice = ctk.CTkLabel(head, text="Fakturanr: –", font=head_font)
+    app.lbl_supplier = ctk.CTkLabel(head, text="Leverandør: –", font=head_font)
     app.lbl_count.grid(row=0, column=0, padx=(4, 12))
     app.lbl_status.grid(row=0, column=1, padx=8)
     app.lbl_invoice.grid(row=0, column=2, padx=8)
-    create_button(head, text="📋 Kopier fakturanr", command=app.copy_invoice).grid(row=0, column=3, padx=(8,0))
+    app.lbl_supplier.grid(row=0, column=3, padx=8)
+    create_button(head, text="📋 Kopier fakturanr", command=app.copy_invoice).grid(row=0, column=4, padx=(8,0))
     app.copy_feedback = ctk.CTkLabel(head, text="", text_color=get_color("success"))
-    app.copy_feedback.grid(row=0, column=4, padx=8, sticky="w")
+    app.copy_feedback.grid(row=0, column=5, padx=8, sticky="w")
 
     app.inline_status = ctk.CTkLabel(head, text="", text_color=get_color("success"))
-    app.inline_status.grid(row=0, column=5, padx=8, sticky="e")
+    app.inline_status.grid(row=0, column=6, padx=8, sticky="e")
 
     btns = ctk.CTkFrame(panel)
     btns.grid(row=1, column=0, sticky="ew", padx=12, pady=(0, 4))

--- a/gui/mainview.py
+++ b/gui/mainview.py
@@ -1,19 +1,18 @@
-from . import (
-    FONT_TITLE,
-    FONT_BODY,
-    FONT_TITLE_LITE,
-    FONT_TITLE_SMALL,
-    FONT_SMALL,
-    create_button,
-    get_color,
-)
+from . import create_button, get_color
+from .style import style
 
 
 def build_main(app):
     import customtkinter as ctk
 
     panel = ctk.CTkFrame(app, corner_radius=16)
-    panel.grid(row=0, column=1, sticky="nsew", padx=(0, 14), pady=14)
+    panel.grid(
+        row=0,
+        column=1,
+        sticky="nsew",
+        padx=(0, style.spacing.padx),
+        pady=style.spacing.pady,
+    )
     panel.grid_columnconfigure(0, weight=1)
     panel.grid_rowconfigure(2, weight=1, minsize=300)
 
@@ -21,9 +20,9 @@ def build_main(app):
     head.grid(row=0, column=0, sticky="ew", padx=12, pady=8)
     head.grid_columnconfigure(6, weight=1)
 
-    head_font = FONT_TITLE_LITE
+    head_font = style.fonts.title_lite
 
-    app.lbl_count = ctk.CTkLabel(head, text="Bilag: –/–", font=FONT_TITLE)
+    app.lbl_count = ctk.CTkLabel(head, text="Bilag: –/–", font=style.fonts.title)
     app.lbl_status = ctk.CTkLabel(head, text="Status: –", font=head_font)
     app.lbl_invoice = ctk.CTkLabel(head, text="Fakturanr: –", font=head_font)
     app.lbl_count.grid(row=0, column=0, padx=(4, 12))
@@ -71,23 +70,23 @@ def build_main(app):
     right.grid(row=0, column=1, sticky="nsew")
     app.right_frame = right
 
-    ctk.CTkLabel(left, text="Detaljer for bilag", font=FONT_TITLE_SMALL)\
+    ctk.CTkLabel(left, text="Detaljer for bilag", font=style.fonts.title_small)\
         .grid(row=0, column=0, sticky="w", padx=8, pady=(4,4))
     left.grid_columnconfigure(0, weight=1)
     left.grid_rowconfigure(1, weight=1, minsize=120)
-    app.detail_box = ctk.CTkTextbox(left, height=360, font=FONT_BODY)
+    app.detail_box = ctk.CTkTextbox(left, height=360, font=style.fonts.body)
     app.detail_box.grid(row=1, column=0, sticky="nsew", padx=(8,6), pady=(0,8))
 
-    ctk.CTkLabel(right, text="Hovedbok (bilagslinjer)", font=FONT_TITLE_SMALL)\
+    ctk.CTkLabel(right, text="Hovedbok (bilagslinjer)", font=style.fonts.title_small)\
         .grid(row=0, column=0, sticky="w", padx=8, pady=(4,4))
     right.grid_columnconfigure(0, weight=1)
     right.grid_columnconfigure(1, weight=0)
     right.grid_rowconfigure(1, weight=3, minsize=150)
     right.grid_rowconfigure(5, weight=1, minsize=80)
 
-    ctk.CTkLabel(right, text="Kommentar", font=FONT_TITLE_SMALL)\
+    ctk.CTkLabel(right, text="Kommentar", font=style.fonts.title_small)\
         .grid(row=4, column=0, columnspan=2, sticky="w", padx=(8, 6), pady=(8, 4))
-    app.comment_box = ctk.CTkTextbox(right, height=110, font=FONT_SMALL)
+    app.comment_box = ctk.CTkTextbox(right, height=110, font=style.fonts.small)
     app.comment_box.grid(row=5, column=0, columnspan=2, sticky="nsew", padx=(8, 6), pady=(0, 0))
 
     bottom = ctk.CTkFrame(panel)

--- a/gui/sidebar.py
+++ b/gui/sidebar.py
@@ -1,13 +1,6 @@
 import os
-from . import (
-    FONT_TITLE,
-    FONT_BODY,
-    FONT_TITLE_LARGE,
-    FONT_BODY_BOLD,
-    FONT_SMALL,
-    FONT_SMALL_ITALIC,
-    create_button,
-)
+from . import create_button
+from .style import style
 
 
 def _toggle_sample_btn(app, *_):
@@ -19,25 +12,31 @@ def build_sidebar(app):
     import customtkinter as ctk
 
     card = ctk.CTkFrame(app, corner_radius=16)
-    card.grid(row=0, column=0, sticky="nsw", padx=14, pady=14)
+    card.grid(
+        row=0,
+        column=0,
+        sticky="nsw",
+        padx=style.spacing.padx,
+        pady=style.spacing.pady,
+    )
 
-    ctk.CTkLabel(card, text="⚙️ Innstillinger", font=FONT_TITLE_LARGE)\
-        .grid(row=0, column=0, padx=14, pady=(14, 6), sticky="w")
+    ctk.CTkLabel(card, text="⚙️ Innstillinger", font=style.fonts.title_large)\
+        .grid(row=0, column=0, padx=style.spacing.padx, pady=(style.spacing.pady, 6), sticky="w")
 
     app.file_path_var = ctk.StringVar(master=app, value="")
     create_button(card, text="Velg leverandørfakturaer (Excel)…", command=app.choose_file)\
-        .grid(row=1, column=0, padx=14, pady=(4, 2), sticky="ew")
+        .grid(row=1, column=0, padx=style.spacing.padx, pady=(4, 2), sticky="ew")
     ctk.CTkLabel(card, textvariable=app.file_path_var, wraplength=260, anchor="w", justify="left")\
-        .grid(row=2, column=0, padx=14, pady=(0, 6), sticky="ew")
+        .grid(row=2, column=0, padx=style.spacing.padx, pady=(0, 6), sticky="ew")
 
     app.gl_path_var = ctk.StringVar(master=app, value="")
     create_button(card, text="Velg hovedbok (Excel)…", command=app.choose_gl_file)\
-        .grid(row=3, column=0, padx=14, pady=(2, 2), sticky="ew")
+        .grid(row=3, column=0, padx=style.spacing.padx, pady=(2, 2), sticky="ew")
     ctk.CTkLabel(card, textvariable=app.gl_path_var, wraplength=260, anchor="w", justify="left")\
-        .grid(row=4, column=0, padx=14, pady=(0, 6), sticky="ew")
+        .grid(row=4, column=0, padx=style.spacing.padx, pady=(0, 6), sticky="ew")
 
     row_utv = ctk.CTkFrame(card)
-    row_utv.grid(row=5, column=0, padx=14, pady=(4, 0), sticky="ew")
+    row_utv.grid(row=5, column=0, padx=style.spacing.padx, pady=(4, 0), sticky="ew")
     ctk.CTkLabel(row_utv, text="Antall tilfeldig utvalg").grid(
         row=0, column=0, padx=(8, 0), sticky="w"
     )
@@ -77,18 +76,18 @@ def build_sidebar(app):
     ).grid(row=1, column=1, padx=(8, 0), pady=(6, 0))
 
     app.sample_btn = create_button(card, text="🎲 Lag utvalg", command=app.make_sample, state="disabled")
-    app.sample_btn.grid(row=6, column=0, padx=14, pady=(8, 6), sticky="ew")
+    app.sample_btn.grid(row=6, column=0, padx=style.spacing.padx, pady=(8, 6), sticky="ew")
 
     app.sample_size_var.trace_add("write", lambda *_: _toggle_sample_btn(app))
     app.year_var.trace_add("write", lambda *_: _toggle_sample_btn(app))
 
-    app.lbl_filecount = ctk.CTkLabel(card, text="Antall bilag: –", font=FONT_TITLE)
-    app.lbl_filecount.grid(row=7, column=0, padx=14, pady=(2, 2), sticky="w")
+    app.lbl_filecount = ctk.CTkLabel(card, text="Antall bilag: –", font=style.fonts.title)
+    app.lbl_filecount.grid(row=7, column=0, padx=style.spacing.padx, pady=(2, 2), sticky="w")
 
-    ctk.CTkLabel(card, text="Oppdragsinfo", font=FONT_BODY_BOLD)\
-        .grid(row=8, column=0, padx=14, pady=(8, 2), sticky="w")
+    ctk.CTkLabel(card, text="Oppdragsinfo", font=style.fonts.body_bold)\
+        .grid(row=8, column=0, padx=style.spacing.padx, pady=(8, 2), sticky="w")
     opp = ctk.CTkFrame(card, corner_radius=8)
-    opp.grid(row=9, column=0, padx=14, pady=(0, 8), sticky="ew")
+    opp.grid(row=9, column=0, padx=style.spacing.padx, pady=(0, 8), sticky="ew")
     opp.grid_columnconfigure(0, weight=0)
     opp.grid_columnconfigure(1, weight=1)
 
@@ -115,7 +114,7 @@ def build_sidebar(app):
     info_lbl = ctk.CTkLabel(
         opp,
         text="Kundenavn hentes automatisk",
-        font=FONT_SMALL_ITALIC,
+        font=style.fonts.small_italic,
         anchor="w",
         justify="left",
         wraplength=240,
@@ -124,18 +123,18 @@ def build_sidebar(app):
 
     card.grid_rowconfigure(20, weight=1)
 
-    ctk.CTkLabel(card, text="Tema", font=FONT_SMALL)\
-        .grid(row=101, column=0, padx=14, pady=(0, 0), sticky="w")
+    ctk.CTkLabel(card, text="Tema", font=style.fonts.small)\
+        .grid(row=101, column=0, padx=style.spacing.padx, pady=(0, 0), sticky="w")
     theme = ctk.CTkSegmentedButton(card, values=["System", "Light", "Dark"], command=app._switch_theme)
     theme.set("System")
-    theme.grid(row=102, column=0, padx=14, pady=(2, 14), sticky="ew")
+    theme.grid(row=102, column=0, padx=style.spacing.padx, pady=(2, style.spacing.pady), sticky="ew")
 
     status_card = ctk.CTkFrame(card, corner_radius=12)
-    status_card.grid(row=100, column=0, padx=14, pady=(8, 14), sticky="ew")
+    status_card.grid(row=100, column=0, padx=style.spacing.padx, pady=(8, style.spacing.pady), sticky="ew")
     status_card.grid_columnconfigure(0, weight=1)
 
-    title_font = FONT_TITLE_LARGE
-    body_font = FONT_BODY
+    title_font = style.fonts.title_large
+    body_font = style.fonts.body
 
     ctk.CTkLabel(status_card, text="Status", font=title_font, anchor="center", justify="center")\
         .grid(row=0, column=0, sticky="ew", pady=(10, 6))

--- a/gui/style.py
+++ b/gui/style.py
@@ -1,0 +1,51 @@
+from dataclasses import dataclass, field
+from typing import Any, Dict
+
+
+@dataclass
+class Colors:
+    """Fargeoppsett for ulike tema og knapper."""
+
+    palette: Dict[str, Dict[str, str]] = field(
+        default_factory=lambda: {
+            "success": {"light": "#2ecc71", "dark": "#27ae60"},
+            "success_hover": {"light": "#29b765", "dark": "#219150"},
+            "error": {"light": "#e74c3c", "dark": "#c0392b"},
+            "error_hover": {"light": "#cf4334", "dark": "#992d22"},
+        }
+    )
+    btn_fg: str = "#1f6aa5"
+    btn_hover: str = "#185a8b"
+    btn_radius: int = 8
+
+
+@dataclass
+class Fonts:
+    """Plassholdere for skrifttyper som initialiseres senere."""
+
+    title: Any = None
+    body: Any = None
+    title_lite: Any = None
+    title_large: Any = None
+    title_small: Any = None
+    body_bold: Any = None
+    small: Any = None
+    small_italic: Any = None
+
+
+@dataclass(frozen=True)
+class Spacing:
+    """Standard spacing i appen."""
+
+    padx: int = 14
+    pady: int = 14
+
+
+@dataclass
+class Style:
+    colors: Colors = field(default_factory=Colors)
+    fonts: Fonts = field(default_factory=Fonts)
+    spacing: Spacing = field(default_factory=Spacing)
+
+
+style = Style()


### PR DESCRIPTION
## Oppsummering
- samlet farger, skrifttyper og spacing i `gui/style.py`
- oppdaterte `gui/__init__.py`, `mainview.py` og `sidebar.py` til å bruke den nye stilmodulen
- erstattet hardkodede paddings og skrifttyper med referanser til `style`

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd42d822b083289429b5c569ac3b97