### PR TITLE
Bruk PanedWindow for justerbar sidebar

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -183,9 +183,15 @@ class App:
 
         self._TkinterDnD = TkinterDnD
 
-        self.grid_columnconfigure(0, weight=0)
-        self.grid_columnconfigure(1, weight=1)
-        self.grid_rowconfigure(0, weight=1)
+        ctk = _ctk()
+        self.paned = tk.PanedWindow(self, orient=tk.HORIZONTAL)
+        self.paned.pack(fill="both", expand=True)
+
+        self.sidebar_frame = ctk.CTkFrame(self.paned)
+        self.main_frame = ctk.CTkFrame(self.paned)
+        self.paned.add(self.sidebar_frame)
+        self.paned.add(self.main_frame)
+        self.paned.paneconfigure(self.sidebar_frame, minsize=260)
 
         self.bind("<Left>", lambda e: self.prev())
         self.bind("<Right>", lambda e: self.next())
@@ -196,14 +202,14 @@ class App:
     def _build_sidebar(self):
         from .sidebar import build_sidebar
 
-        self.sidebar = build_sidebar(self)
+        self.sidebar = build_sidebar(self, self.sidebar_frame)
         self.sample_size_var.set("")
         self.year_var.set("")
 
     def _build_main(self):
         from .mainview import build_main
 
-        self.main = build_main(self)
+        self.main = build_main(self, self.main_frame)
         if self.gl_df is not None:
             self.after(0, self._build_ledger_widgets)
         self.render()

--- a/gui/mainview.py
+++ b/gui/mainview.py
@@ -133,11 +133,11 @@ def build_bottom(app):
     return bottom
 
 
-def build_main(app):
+def build_main(app, master):
     import customtkinter as ctk
 
-    panel = ctk.CTkFrame(app, corner_radius=16)
-    panel.grid(row=0, column=1, sticky="nsew", padx=(0, style.PAD_XL), pady=style.PAD_XL)
+    panel = ctk.CTkFrame(master, corner_radius=16)
+    panel.pack(fill="both", expand=True, padx=(0, style.PAD_XL), pady=style.PAD_XL)
     panel.grid_columnconfigure(0, weight=1)
     panel.grid_rowconfigure(2, weight=1, minsize=300)
 

--- a/gui/sidebar.py
+++ b/gui/sidebar.py
@@ -8,11 +8,11 @@ def _toggle_sample_btn(app, *_):
     app.sample_btn.configure(state=state)
 
 
-def build_sidebar(app):
+def build_sidebar(app, master):
     import customtkinter as ctk
 
-    card = ctk.CTkFrame(app, corner_radius=16)
-    card.grid(row=0, column=0, sticky="nsw", padx=style.PAD_XL, pady=style.PAD_XL)
+    card = ctk.CTkFrame(master, corner_radius=16)
+    card.pack(fill="both", expand=True, padx=style.PAD_XL, pady=style.PAD_XL)
 
     ctk.CTkLabel(card, text="⚙️ Innstillinger", font=style.FONT_TITLE_LARGE)\
         .grid(row=0, column=0, padx=style.PAD_XL, pady=(style.PAD_XL, style.PAD_SM), sticky="w")


### PR DESCRIPTION
## Sammendrag
- Bytter ut grid-layout med horisontal `PanedWindow` og separate `CTkFrame` for sidepanel og hoveddel.
- Oppdaterer `build_sidebar` og `build_main` til å bruke egne rammer.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd53be2e408328962a72c87602c24a