### PR TITLE
Forhåndspars nettobeløp og vektoriser summer

### DIFF
--- a/tests/test_calc_sum_net_all.py
+++ b/tests/test_calc_sum_net_all.py
@@ -7,7 +7,8 @@ def test_calc_sum_net_all_uten_summeringsrad():
         'tekst': ['rad1', 'rad2', None],
         'netto': [100.0, 200.0, 0.0]
     })
-    assert calc_sum_net_all(df, 'netto') == 300.0
+    df['_netto_float'] = df['netto']
+    assert calc_sum_net_all(df) == 300.0
 
 
 def test_calc_sum_net_all_med_summeringsrader():
@@ -15,7 +16,8 @@ def test_calc_sum_net_all_med_summeringsrader():
         'tekst': ['rad1', 'Sum', 'rad2', 'SUM'],
         'netto': [100.0, 999.0, 200.0, 300.0]
     })
-    assert calc_sum_net_all(df, 'netto') == 300.0
+    df['_netto_float'] = df['netto']
+    assert calc_sum_net_all(df) == 300.0
 
 
 def test_calc_sum_net_all_kun_summeringsrad():
@@ -23,7 +25,8 @@ def test_calc_sum_net_all_kun_summeringsrad():
         'tekst': ['Sum'],
         'netto': [123.0]
     })
-    assert calc_sum_net_all(df, 'netto') == 0.0
+    df['_netto_float'] = df['netto']
+    assert calc_sum_net_all(df) == 0.0
 
 
 def test_calc_sum_net_all_beholder_siste_rad_uten_sum():
@@ -31,4 +34,5 @@ def test_calc_sum_net_all_beholder_siste_rad_uten_sum():
         'tekst': ['rad1', 'rad2', 'rad3'],
         'netto': [100.0, 200.0, 300.0]
     })
-    assert calc_sum_net_all(df, 'netto') == 600.0
+    df['_netto_float'] = df['netto']
+    assert calc_sum_net_all(df) == 600.0

--- a/tests/test_status_card.py
+++ b/tests/test_status_card.py
@@ -17,6 +17,7 @@ class DummyWidget:
 class FakeApp:
     def __init__(self):
         self.df = pd.DataFrame({'Faktura':[1], 'Beløp':[100]})
+        self.df['_netto_float'] = self.df['Beløp'].astype(float)
         self.sample_df = self.df.copy()
         self.idx = 0
         self.invoice_col = 'Faktura'


### PR DESCRIPTION
## Oppsummering
- Laster nå nettobeløp som `_netto_float` ved innlesing av fakturaliste.
- Vektoriserer summering av kontrollert og totalt nettobeløp via nye helper-funksjoner.
- Statuskort og rapport bruker de forhåndsparsede verdiene for raskere beregninger.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd5a6c26f88328ab6da8814072db10