### PR TITLE
Fet skrift for beløpsfelt i detaljvisning

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -650,7 +650,20 @@ class App:
 
             row_dict = self._current_row_dict()
             self.detail_box.configure(state="normal"); self.detail_box.delete("0.0","end")
-            self.detail_box.insert("0.0", self._details_text_for_row(row_dict)); self.detail_box.configure(state="disabled")
+            details = self._details_text_for_row(row_dict)
+            for line in details.splitlines():
+                if not line:
+                    continue
+                if ":" in line:
+                    key, val = line.split(":", 1)
+                    if key.strip().lower() in {"nettobeløp", "mva", "totalbeløp"}:
+                        self.detail_box.insert("end", f"{key}:", "bold")
+                        self.detail_box.insert("end", f"{val}\n")
+                    else:
+                        self.detail_box.insert("end", line + "\n")
+                else:
+                    self.detail_box.insert("end", line + "\n")
+            self.detail_box.configure(state="disabled")
 
             if hasattr(self, "populate_ledger_table") and hasattr(self, "ledger_tree"):
                 self.populate_ledger_table(self, inv_val)

--- a/gui/mainview.py
+++ b/gui/mainview.py
@@ -80,6 +80,8 @@ def build_panes(app):
     left.grid_rowconfigure(1, weight=1, minsize=120)
     app.detail_box = ctk.CTkTextbox(left, height=360, font=style.FONT_BODY)
     app.detail_box.grid(row=1, column=0, sticky="nsew", padx=(style.PAD_MD, style.PAD_SM), pady=(0, style.PAD_MD))
+    # Konfigurer tag for fet tekst i detaljboksen
+    app.detail_box.tag_configure("bold", font=style.FONT_BODY_BOLD)
 
     ctk.CTkLabel(right, text="Hovedbok (bilagslinjer)", font=style.FONT_TITLE_SMALL)\
         .grid(row=0, column=0, sticky="w", padx=style.PAD_MD, pady=(style.PAD_XS, style.PAD_XS))


### PR DESCRIPTION
## Sammendrag
- gjør det mulig å vise nettobeløp, mva og totalbeløp med fet skrift i detaljboksen
- legger til tag-konfigurasjon for fet tekst i GUI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd5da02ed88328ad2d16a5d894b54e