### PR TITLE
Legg til modal ventedialog ved import og eksport

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -319,6 +319,8 @@ class App:
         p = filedialog.askopenfilename(title="Velg Excel (fakturaliste)", filetypes=[("Excel","*.xlsx *.xls")])
         if not p: return
         self.file_path_var.set(p)
+        from .busy import show_busy
+        show_busy(self, "Laster fakturaliste...")
         self._load_excel()
 
     def choose_gl_file(self):
@@ -326,6 +328,8 @@ class App:
         p = filedialog.askopenfilename(title="Velg Hovedbok (Excel)", filetypes=[("Excel","*.xlsx *.xls")])
         if not p: return
         self.gl_path_var.set(p)
+        from .busy import show_busy
+        show_busy(self, "Laster hovedbok...")
         self._load_gl_excel()
 
     def destroy(self):
@@ -363,6 +367,8 @@ class App:
             if big and hasattr(self, "inline_status"):
                 self.inline_status.configure(text="")
             self._finish_progress()
+            from .busy import hide_busy
+            hide_busy(self)
 
         def worker():
             try:
@@ -423,6 +429,8 @@ class App:
             if big and hasattr(self, "inline_status"):
                 self.inline_status.configure(text="")
             self._finish_progress()
+            from .busy import hide_busy
+            hide_busy(self)
 
         def worker():
             try:

--- a/gui/busy.py
+++ b/gui/busy.py
@@ -1,0 +1,35 @@
+from . import _ctk
+
+
+def show_busy(app, message: str):
+    """Vis en modal ventedialog med en spinner og tekst."""
+    ctk = _ctk()
+    win = ctk.CTkToplevel(app)
+    win.title("")
+    win.resizable(False, False)
+    win.transient(app)
+    win.grab_set()
+
+    progress = ctk.CTkProgressBar(win, mode="indeterminate")
+    progress.pack(padx=20, pady=(20, 10), fill="x")
+    progress.start()
+    ctk.CTkLabel(win, text=message).pack(padx=20, pady=(0, 20))
+
+    app._busy_win = win
+    win.update_idletasks()
+    x = app.winfo_x() + app.winfo_width() // 2 - win.winfo_width() // 2
+    y = app.winfo_y() + app.winfo_height() // 2 - win.winfo_height() // 2
+    win.geometry(f"+{x}+{y}")
+    return win
+
+
+def hide_busy(app):
+    """Lukk ventedialogen hvis den er åpen."""
+    win = getattr(app, "_busy_win", None)
+    if win is not None:
+        try:
+            win.grab_release()
+        except Exception:
+            pass
+        win.destroy()
+        app._busy_win = None

--- a/gui/mainview.py
+++ b/gui/mainview.py
@@ -107,8 +107,12 @@ def build_bottom(app):
 
     def _export_pdf():
         from report import export_pdf
-
-        export_pdf(app)
+        from .busy import show_busy, hide_busy
+        show_busy(app, "Eksporterer rapport...")
+        try:
+            export_pdf(app)
+        finally:
+            hide_busy(app)
 
     create_button(bottom, text="📄 Eksporter PDF rapport", command=_export_pdf).pack(side="left")
 


### PR DESCRIPTION
## Sammendrag
- Opprett egen `busy`-modul med `show_busy`/`hide_busy`
- Vis ventedialog når filer lastes inn og rapport eksporteres
- Lukk ventedialogen når prosessene er ferdige

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd633a0c5483288f324f14c17be723