### PR TITLE
Bytt til CTkProgressBar i hovedvisning

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -615,7 +615,7 @@ class App:
         if hasattr(self, "progress_bar"):
             if progress is not None:
                 self.progress_bar.pack(side="right", padx=style.PAD_SM)
-                self.progress_bar.configure(value=max(0, min(100, progress)))
+                self.progress_bar.set(max(0, min(1, progress / 100)))
                 self.progress_bar.update_idletasks()
             else:
                 self.progress_bar.pack_forget()

--- a/gui/mainview.py
+++ b/gui/mainview.py
@@ -98,7 +98,6 @@ def build_panes(app):
 
 def build_bottom(app):
     import customtkinter as ctk
-    from tkinter import ttk
 
     panel = app.main_panel
     bottom = ctk.CTkFrame(panel)
@@ -119,18 +118,13 @@ def build_bottom(app):
     app.status_label = ctk.CTkLabel(bottom, text="")
     app.status_label.pack(side="left", expand=True, fill="x", padx=style.PAD_SM)
 
-    pb_style = ttk.Style()
-    pb_style.configure(
-        "green.Horizontal.TProgressbar",
-        background=style.get_color("success"),
-    )
-    app.progress_bar = ttk.Progressbar(
+    app.progress_bar = ctk.CTkProgressBar(
         bottom,
-        mode="determinate",
-        length=120,
-        maximum=100,
-        style="green.Horizontal.TProgressbar",
+        width=120,
+        progress_color=style.get_color("success"),
+        fg_color=style.get_color("bg"),
     )
+    app.progress_bar.set(0)
     app.progress_bar.pack(side="right", padx=style.PAD_SM)
     app.progress_bar.pack_forget()
 


### PR DESCRIPTION
## Sammendrag
- Erstattet `ttk.Progressbar` med `CTkProgressBar` og fjernet `ttk.Style`-bruk i `build_bottom`.
- Tilpasset `_set_status` til den nye framgangslinjen med verdiområde 0–1.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd65aa86308328aa324f5aa582392b