### PR TITLE
Flytt tema-valg til knapp i toppfeltet

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -276,6 +276,31 @@ class App:
         update_treeview_stripes(self)
         self.render()
 
+    def _open_theme_menu(self):
+        ctk = _ctk()
+        win = ctk.CTkToplevel(self)
+        win.title("Tema")
+        win.transient(self)
+        win.resizable(False, False)
+        try:
+            current = ctk.get_appearance_mode().capitalize()
+        except Exception:
+            current = "System"
+        if current not in ("System", "Light", "Dark"):
+            current = "System"
+        ctk.CTkLabel(win, text="Velg tema", font=style.FONT_BODY_BOLD).pack(
+            padx=style.PAD_MD, pady=(style.PAD_MD, style.PAD_SM)
+        )
+
+        def _apply(mode):
+            self._switch_theme(mode)
+            win.destroy()
+
+        seg = ctk.CTkSegmentedButton(win, values=["System", "Light", "Dark"], command=_apply)
+        seg.set(current)
+        seg.pack(padx=style.PAD_MD, pady=(0, style.PAD_MD))
+        win.grab_set()
+
     def _update_icon(self):
         ctk = _ctk()
         from helpers import resource_path

--- a/gui/mainview.py
+++ b/gui/mainview.py
@@ -25,6 +25,9 @@ def build_header(app):
     app.inline_status = ctk.CTkLabel(head, text="", text_color=style.get_color("success"))
     app.inline_status.grid(row=0, column=5, padx=style.PAD_MD, sticky="e")
 
+    app.theme_btn = create_button(head, text="Tema", command=app._open_theme_menu)
+    app.theme_btn.grid(row=0, column=7, padx=style.PAD_MD, sticky="e")
+
     return head
 
 

--- a/gui/sidebar.py
+++ b/gui/sidebar.py
@@ -147,12 +147,6 @@ def build_sidebar(app):
 
     card.grid_rowconfigure(20, weight=1)
 
-    ctk.CTkLabel(card, text="Tema", font=style.FONT_SMALL)\
-        .grid(row=101, column=0, padx=style.PAD_XL, pady=(0, 0), sticky="w")
-    theme = ctk.CTkSegmentedButton(card, values=["System", "Light", "Dark"], command=app._switch_theme)
-    theme.set("System")
-    theme.grid(row=102, column=0, padx=style.PAD_XL, pady=(style.PAD_XXS, style.PAD_XL), sticky="ew")
-
     status_card = ctk.CTkFrame(card, corner_radius=12)
     status_card.grid(row=100, column=0, padx=style.PAD_XL, pady=(style.PAD_MD, style.PAD_XL), sticky="ew")
     status_card.grid_columnconfigure(0, weight=1)


### PR DESCRIPTION
## Sammendrag
- Flytter temavelger ut av sidepanelet og inn i en egen knapp i toppfeltet
- Knappen åpner dialog for valg av System, Light eller Dark

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd806e560483288bd1ffe52328c79f