### PR TITLE
Flytt temavalget til toppmeny

### DIFF
--- a/gui/mainview.py
+++ b/gui/mainview.py
@@ -25,6 +25,17 @@ def build_header(app):
     app.inline_status = ctk.CTkLabel(head, text="", text_color=style.get_color("success"))
     app.inline_status.grid(row=0, column=5, padx=style.PAD_MD, sticky="e")
 
+    ctk.CTkLabel(head, text="Temavalg").grid(row=0, column=7, padx=(style.PAD_MD, style.PAD_XS))
+    app.theme_var = ctk.StringVar(value="System")
+    app.theme_menu = ctk.CTkOptionMenu(
+        head,
+        variable=app.theme_var,
+        values=["System", "Light", "Dark"],
+        command=app._switch_theme,
+    )
+    app.theme_menu.grid(row=0, column=8, padx=(0, style.PAD_MD))
+    app.theme_menu.set("System")
+
     return head
 
 

--- a/gui/sidebar.py
+++ b/gui/sidebar.py
@@ -147,12 +147,6 @@ def build_sidebar(app):
 
     card.grid_rowconfigure(20, weight=1)
 
-    ctk.CTkLabel(card, text="Tema", font=style.FONT_SMALL)\
-        .grid(row=101, column=0, padx=style.PAD_XL, pady=(0, 0), sticky="w")
-    theme = ctk.CTkSegmentedButton(card, values=["System", "Light", "Dark"], command=app._switch_theme)
-    theme.set("System")
-    theme.grid(row=102, column=0, padx=style.PAD_XL, pady=(style.PAD_XXS, style.PAD_XL), sticky="ew")
-
     status_card = ctk.CTkFrame(card, corner_radius=12)
     status_card.grid(row=100, column=0, padx=style.PAD_XL, pady=(style.PAD_MD, style.PAD_XL), sticky="ew")
     status_card.grid_columnconfigure(0, weight=1)


### PR DESCRIPTION
## Sammendrag
- Flytt tema-valg frå sidepanelet til ei ny "Temavalg"-knapp i toppmenyen.
- Bruk rullgardin for å velje mellom System, Light og Dark med System som standard.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd893c4e248328a4cd9a1a8ae06075