### PR TITLE
Retter hvite dra-og-slipp-felt i mørk modus

### DIFF
--- a/gui/sidebar.py
+++ b/gui/sidebar.py
@@ -25,15 +25,15 @@ def build_sidebar(app):
             parent,
             height=70,
             corner_radius=style.BTN_RADIUS,
-            fg_color=style.get_color("dnd_bg"),
-            border_color=style.get_color("dnd_border"),
+            fg_color=style.get_color_pair("dnd_bg"),
+            border_color=style.get_color_pair("dnd_border"),
             border_width=2,
         )
         ctk.CTkLabel(
             frame,
             text=text,
             anchor="center",
-            text_color=style.get_color("dnd_border"),
+            text_color=style.get_color_pair("dnd_border"),
         ).pack(expand=True, fill="both", padx=style.PAD_MD, pady=style.PAD_SM)
         return frame
 

--- a/gui/style.py
+++ b/gui/style.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Dict, Optional
+from typing import Dict, Optional, Tuple
 
 
 @dataclass
@@ -42,6 +42,14 @@ class Style:
         mode = ctk.get_appearance_mode().lower()
         try:
             return self.COLORS[name]["dark" if mode == "dark" else "light"]
+        except KeyError as e:
+            raise KeyError(f"Ukjent fargenavn: {name}") from e
+
+    def get_color_pair(self, name: str) -> Tuple[str, str]:
+        """Returner (lys, mørk) fargepar for CustomTkinter-komponenter."""
+        try:
+            col = self.COLORS[name]
+            return col["light"], col["dark"]
         except KeyError as e:
             raise KeyError(f"Ukjent fargenavn: {name}") from e
 


### PR DESCRIPTION
## Sammendrag
- legger til `get_color_pair` for å få lys/mørk fargepar
- bruker fargepar i dra-og-slipp-feltene slik at de følger valgt tema

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd8b54d48883289d18713582181ce2