### PR TITLE
Juster kolonnebredder ved vinduendringer

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -351,6 +351,11 @@ class App:
     def destroy(self):
         ctk = _ctk()
         try:
+            if hasattr(self, "ledger_tree") and hasattr(self, "_ledger_configure_id"):
+                self.ledger_tree.unbind("<Configure>", self._ledger_configure_id)
+        except Exception:
+            pass
+        try:
             ctk.ScalingTracker.remove_window(self.destroy, self)
         except Exception:
             pass

--- a/gui/ledger.py
+++ b/gui/ledger.py
@@ -123,7 +123,7 @@ def ledger_rows(app, invoice_value: str):
     return rows
 
 
-def autofit_tree_columns(tree, cols):
+def autofit_tree_columns(tree, cols, total_width=None):
     import tkinter.font as tkfont
 
     body_font = tkfont.nametofont("TkDefaultFont")
@@ -131,6 +131,8 @@ def autofit_tree_columns(tree, cols):
         head_font = tkfont.nametofont("TkHeadingFont")
     except Exception:
         head_font = body_font
+
+    widths: list[int] = []
     for col in cols:
         max_px = head_font.measure(col)
         for iid in tree.get_children(""):
@@ -139,7 +141,16 @@ def autofit_tree_columns(tree, cols):
             if px > max_px:
                 max_px = px
         max_px = max(70, min(max_px + 24, 500))
-        tree.column(col, width=max_px)
+        widths.append(max_px)
+
+    if total_width:
+        total_content = sum(widths)
+        if total_content < total_width:
+            extra = (total_width - total_content) // len(widths)
+            widths = [w + extra for w in widths]
+
+    for col, w in zip(cols, widths):
+        tree.column(col, width=w)
 
 
 def populate_ledger_table(app, invoice_value: str):

--- a/gui/mainview.py
+++ b/gui/mainview.py
@@ -160,6 +160,12 @@ def build_main(app):
     return panel
 
 
+def resize_ledger_columns(app):
+    from . import ledger
+    width = app.ledger_tree.winfo_width()
+    ledger.autofit_tree_columns(app.ledger_tree, app.ledger_cols, width)
+
+
 def build_ledger_widgets(app):
     from tkinter import ttk
     import customtkinter as ctk
@@ -197,6 +203,10 @@ def build_ledger_widgets(app):
     app.ledger_tree.grid(row=1, column=0, sticky="nsew")
     yscroll.grid(row=1, column=1, sticky="ns")
     xscroll.grid(row=2, column=0, sticky="ew")
+
+    app._ledger_configure_id = app.ledger_tree.bind(
+        "<Configure>", lambda e: resize_ledger_columns(app)
+    )
 
     apply_treeview_theme(app)
     update_treeview_stripes(app)


### PR DESCRIPTION
## Sammendrag
- Legg til `resize_ledger_columns` for å tilpasse kolonnebredder til vinduets bredde
- Bind `<Configure>`-hendelsen på hovedboktabellen og fjern bindingen ved avslutning
- Utvid `autofit_tree_columns` til å håndtere total bredde

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bd8d98497c83288d26094fe1f701a7