### PR TITLE
Standardiser padding i GUI

### DIFF
--- a/gui/AGENTS.md
+++ b/gui/AGENTS.md
@@ -1,0 +1,6 @@
+# Retningslinjer for GUI-spacing
+
+- Bruk `PADDING_X` og `PADDING_Y` fra `style.py` for standard horisontal og vertikal padding.
+- Unngå å hardkode tallverdier i `padx` og `pady`. Bruk heller konstanter eller multipler av disse.
+- Når det trengs ekstra luft, bruk multipler av `PADDING_X`/`PADDING_Y` eller eksisterende `style.PAD_*` verdier.
+

--- a/gui/busy.py
+++ b/gui/busy.py
@@ -1,4 +1,5 @@
 from . import _ctk
+from .style import PADDING_X, PADDING_Y
 
 
 def show_busy(app, message: str):
@@ -11,9 +12,9 @@ def show_busy(app, message: str):
     win.grab_set()
 
     progress = ctk.CTkProgressBar(win, mode="indeterminate")
-    progress.pack(padx=20, pady=(20, 10), fill="x")
+    progress.pack(padx=PADDING_X * 2, pady=(PADDING_Y * 2, PADDING_Y), fill="x")
     progress.start()
-    ctk.CTkLabel(win, text=message).pack(padx=20, pady=(0, 20))
+    ctk.CTkLabel(win, text=message).pack(padx=PADDING_X * 2, pady=(0, PADDING_Y * 2))
 
     app._busy_win = win
     win.update_idletasks()

--- a/gui/mainview.py
+++ b/gui/mainview.py
@@ -1,5 +1,5 @@
 from . import create_button
-from .style import style
+from .style import style, PADDING_Y
 
 
 def build_header(app):
@@ -212,4 +212,11 @@ def build_ledger_widgets(app):
     update_treeview_stripes(app)
 
     app.ledger_sum = ctk.CTkLabel(right, text=" ", anchor="e", justify="right")
-    app.ledger_sum.grid(row=3, column=0, columnspan=2, sticky="ew", padx=(0, style.PAD_LG), pady=(style.PAD_SM, 10))
+    app.ledger_sum.grid(
+        row=3,
+        column=0,
+        columnspan=2,
+        sticky="ew",
+        padx=(0, style.PAD_LG),
+        pady=(style.PAD_SM, PADDING_Y),
+    )

--- a/gui/sidebar.py
+++ b/gui/sidebar.py
@@ -1,6 +1,6 @@
 import os
 from . import create_button
-from .style import style
+from .style import style, PADDING_Y
 
 
 def _toggle_sample_btn(app, *_):
@@ -152,7 +152,7 @@ def build_sidebar(app):
     body_font = style.FONT_BODY
 
     ctk.CTkLabel(status_card, text="Status", font=title_font, anchor="center", justify="center")\
-        .grid(row=0, column=0, sticky="ew", pady=(10, style.PAD_SM))
+        .grid(row=0, column=0, sticky="ew", pady=(PADDING_Y, style.PAD_SM))
 
     app.lbl_st_sum_kontrollert = ctk.CTkLabel(status_card, text="Sum kontrollert: –", font=body_font, anchor="center", justify="center")
     app.lbl_st_sum_kontrollert.grid(row=1, column=0, sticky="ew", pady=(0, style.PAD_XXS))
@@ -170,6 +170,6 @@ def build_sidebar(app):
     app.lbl_st_ikkegodkjent.grid(row=5, column=0, sticky="ew", pady=(0, style.PAD_XXS))
 
     app.lbl_st_gjen = ctk.CTkLabel(status_card, text="Gjenstår å kontrollere: –", font=body_font, anchor="center", justify="center")
-    app.lbl_st_gjen.grid(row=6, column=0, sticky="ew", pady=(style.PAD_SM, 10))
+    app.lbl_st_gjen.grid(row=6, column=0, sticky="ew", pady=(style.PAD_SM, PADDING_Y))
 
     return card

--- a/gui/style.py
+++ b/gui/style.py
@@ -2,6 +2,11 @@ from dataclasses import dataclass, field
 from typing import Dict, Optional, Tuple
 
 
+# Standard padding for GUI-komponenter
+PADDING_X = 10
+PADDING_Y = 8
+
+
 @dataclass
 class Style:
     """Samler felles stilkonfigurasjon for GUI."""


### PR DESCRIPTION
## Sammendrag
- definerer PADDING_X og PADDING_Y i style.py
- bruker konstanter i busy.py, mainview.py og sidebar.py
- dokumenterer spacing-regler i gui/AGENTS.md

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd91ed07948328941e9fc8b355555c