### PR TITLE
Skjul _netto_float i PDF-rapporten

### DIFF
--- a/report.py
+++ b/report.py
@@ -169,8 +169,9 @@ def create_invoice_section(app, styles, small):
         dec = app.decisions[i] if i < len(app.decisions) else ""
         com = app.comments[i].strip() if i < len(app.comments) else ""
         rows = [["Felt", "Verdi"]]
-        row_dict = {str(c): to_str(r[c]) for c in app.sample_df.columns}
-        for k in app.sample_df.columns:
+        cols = [c for c in app.sample_df.columns if not str(c).startswith("_")]
+        row_dict = {str(c): to_str(r[c]) for c in cols}
+        for k in cols:
             key = str(k)
             val = to_str(row_dict.get(key, ""))
             if not val:

--- a/tests/test_hide_netto_float.py
+++ b/tests/test_hide_netto_float.py
@@ -1,6 +1,8 @@
 import pandas as pd
 import gui
 from gui import App
+import report
+from reportlab.lib.styles import getSampleStyleSheet
 
 class DummyApp:
     def __init__(self):
@@ -8,9 +10,14 @@ class DummyApp:
             {"Faktura": 1, "_netto_float": 408}
         ])
         self.idx = 0
+        self.decisions = [None]
+        self.comments = [""]
+        self.invoice_col = "Faktura"
     def _ensure_helpers(self):
         gui.to_str = str
         gui.format_number_with_thousands = lambda x: x
+    def _set_status(self, *args, **kwargs):
+        pass
 
 def test_netto_float_hidden_in_details():
     app = DummyApp()
@@ -19,3 +26,12 @@ def test_netto_float_hidden_in_details():
     text = App._details_text_for_row(app, row)
     assert "_netto_float" not in text
     assert "Faktura: 1" in text
+
+
+def test_netto_float_hidden_in_pdf(monkeypatch):
+    app = DummyApp()
+    styles = getSampleStyleSheet()
+    monkeypatch.setattr(report, "build_ledger_table", lambda *args, **kwargs: "ledger")
+    flow = report.create_invoice_section(app, styles, styles["BodyText"])
+    table = flow[1]
+    assert "_netto_float" not in [row[0] for row in table._cellvalues]


### PR DESCRIPTION
## Sammendrag
- Skjuler interne kolonner som `_netto_float` ved generering av PDF-rapporten.
- Legger til enhetstest som bekrefter at `_netto_float` ikke vises i PDF-detaljer.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdbbb0bfa08328962f64abadd450aa