### PR TITLE
Uthev drop-soner ved dra-og-slipp

### DIFF
--- a/gui/sidebar.py
+++ b/gui/sidebar.py
@@ -23,20 +23,36 @@ def build_sidebar(app):
     create_button(card, text="Velg leverandørfakturaer (Excel)…", command=app.choose_file)\
         .grid(row=1, column=0, padx=style.PAD_XL, pady=(style.PAD_XS, style.PAD_XXS), sticky="ew")
     def _create_drop_zone(parent, text):
+        dnd_bg = style.get_color_pair("dnd_bg")
+        dnd_border = style.get_color_pair("dnd_border")
+        highlight = style.get_color_pair("success")
+
         frame = ctk.CTkFrame(
             parent,
             height=70,
             corner_radius=style.BTN_RADIUS,
-            fg_color=style.get_color_pair("dnd_bg"),
-            border_color=style.get_color_pair("dnd_border"),
+            fg_color=dnd_bg,
+            border_color=dnd_border,
             border_width=2,
         )
+
+        def _reset_colors(_=None):
+            frame.configure(fg_color=dnd_bg, border_color=dnd_border)
+
+        def _on_drag_enter(_):
+            frame.configure(fg_color=highlight, border_color=highlight)
+
+        frame.dnd_bind("<<DragEnter>>", _on_drag_enter)
+        frame.dnd_bind("<<DragLeave>>", _reset_colors)
+
         ctk.CTkLabel(
             frame,
             text=text,
             anchor="center",
-            text_color=style.get_color_pair("dnd_border"),
+            text_color=dnd_border,
         ).pack(expand=True, fill="both", padx=style.PAD_MD, pady=style.PAD_SM)
+
+        frame.reset_colors = _reset_colors
         return frame
 
     app.inv_drop = _create_drop_zone(card, "Dra og slipp fakturaliste her")
@@ -53,6 +69,7 @@ def build_sidebar(app):
         .grid(row=6, column=0, padx=style.PAD_XL, pady=(0, style.PAD_SM), sticky="ew")
 
     def _drop_invoice(event):
+        app.inv_drop.reset_colors()
         path = event.data.strip("{}").strip()
         if not path.lower().endswith((".xlsx", ".xls")):
             return
@@ -60,8 +77,10 @@ def build_sidebar(app):
         from .busy import show_busy
         show_busy(app, "Laster fakturaliste...")
         app._load_excel()
+        app.inv_drop.reset_colors()
 
     def _drop_gl(event):
+        app.gl_drop.reset_colors()
         path = event.data.strip("{}").strip()
         if not path.lower().endswith((".xlsx", ".xls")):
             return
@@ -69,6 +88,7 @@ def build_sidebar(app):
         from .busy import show_busy
         show_busy(app, "Laster hovedbok...")
         app._load_gl_excel()
+        app.gl_drop.reset_colors()
 
     app.add_drop_target(app.inv_drop, _drop_invoice)
     app.add_drop_target(app.gl_drop, _drop_gl)


### PR DESCRIPTION
## Oppsummering
- Uthev drop-soner ved drag-enter med tydelig farge
- Tilbakestill farger når drag forlater og etter drop

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdc19fe2488328b43a31e5a88c39c7