### PR TITLE
Flytt datetime-import til _update_year_options

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -3,7 +3,6 @@
 
 import os
 import re
-from datetime import datetime
 
 from .style import style
 
@@ -389,6 +388,7 @@ class App:
 
     # Read
     def _update_year_options(self):
+        from datetime import datetime
         years: set[int] = set()
         for df in (getattr(self, "df", None), getattr(self, "gl_df", None)):
             if df is None or "Fakturadato" not in df.columns:


### PR DESCRIPTION
## Oppsummering
- Fjerner global `datetime`-import i GUI-modulen.
- Importerer `datetime` lokalt i `_update_year_options` for å begrense scopet.

## Testing
- `python - <<'PY' ...` (verifiserer at årsfeltet fylles korrekt)
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c40519bec883288e37c515657ad67a