### PR TITLE
Flytt resource_path til egen modul

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -297,7 +297,7 @@ class App:
 
     def _update_icon(self):
         ctk = _ctk()
-        from helpers import resource_path
+        from helpers_path import resource_path
         try:
             dark = ctk.get_appearance_mode().lower() == "dark"
         except Exception:
@@ -316,7 +316,7 @@ class App:
 
     def load_logo_images(self):
         ctk = _ctk()
-        from helpers import resource_path
+        from helpers_path import resource_path
         try:
             from PIL import Image
             img_light = Image.open(resource_path("icons/bilagskontroll_logo_256.png"))

--- a/gui/sidebar.py
+++ b/gui/sidebar.py
@@ -197,7 +197,7 @@ def build_sidebar(app):
 
     try:
         from PIL import Image
-        from helpers import resource_path
+        from helpers_path import resource_path
 
         img_light = Image.open(resource_path("icons/borev_logo_lightmode.png"))
         img_dark = Image.open(resource_path("icons/borev_logo_darkmode.png"))

--- a/helpers.py
+++ b/helpers.py
@@ -77,11 +77,6 @@ NET_AMOUNT_PATS = [
 ]
 
 
-def resource_path(relpath: str) -> str:
-    base = getattr(sys, "_MEIPASS", os.path.dirname(os.path.abspath(__file__)))
-    return os.path.join(base, relpath)
-
-
 def to_str(v):
     pd = _pd()
     if pd.isna(v):

--- a/helpers_path.py
+++ b/helpers_path.py
@@ -1,0 +1,8 @@
+import os
+import sys
+
+
+def resource_path(relpath: str) -> str:
+    base = getattr(sys, "_MEIPASS", os.path.dirname(os.path.abspath(__file__)))
+    return os.path.join(base, relpath)
+


### PR DESCRIPTION
## Sammendrag
- Flyttet `resource_path` til ny modul `helpers_path`
- Oppdaterte GUI-komponenter til å importere `resource_path` fra den nye modulen
- Fjernet den gamle `resource_path`-definisjonen fra `helpers.py`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c56ffb6fc08328bf1e4530e0aac86b