### PR TITLE
Bruk lazy import for DropZone

### DIFF
--- a/gui/dropzone.py
+++ b/gui/dropzone.py
@@ -1,5 +1,7 @@
-import customtkinter as ctk
+from . import _ctk
 from .style import style
+
+ctk = _ctk()
 
 
 class DropZone(ctk.CTkFrame):


### PR DESCRIPTION
## Sammendrag
- Henter CustomTkinter via _ctk for å unngå unødvendig import ved oppstart

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c66df1feb48328b82e8de5e125f792