### PR TITLE
Strammere unntakshåndtering og logging

### DIFF
--- a/data_utils.py
+++ b/data_utils.py
@@ -97,7 +97,8 @@ def extract_customer_from_invoice_file(
             df = pd.read_excel(path, engine="openpyxl", header=None, nrows=2)
         else:
             df = df.head(2)
-    except Exception:
+    except (OSError, ValueError):
+        logger.exception("Kunne ikke lese kundedata")
         return None
     if df is None or len(df) < 2:
         return None

--- a/gui/busy.py
+++ b/gui/busy.py
@@ -1,5 +1,7 @@
 import threading
+from tkinter import TclError
 
+from helpers import logger
 from . import _ctk
 from .style import PADDING_X, PADDING_Y
 
@@ -39,7 +41,7 @@ def hide_busy(app):
     if win is not None:
         try:
             win.grab_release()
-        except Exception:
-            pass
+        except TclError:
+            logger.debug("Kunne ikke frigjøre vinduets grab")
         win.destroy()
         app._busy_win = None

--- a/gui/ledger.py
+++ b/gui/ledger.py
@@ -2,14 +2,14 @@ LEDGER_COLS = ["Kontonr", "Konto", "Beskrivelse", "MVA", "MVA-beløp", "Beløp",
 
 
 def apply_treeview_theme(app):
-    from tkinter import ttk
+    from tkinter import ttk, TclError
     import customtkinter as ctk
     from .style import style
 
     ttk_style = ttk.Style()
     try:
         ttk_style.theme_use("clam")
-    except Exception:
+    except TclError:
         pass
     font = (
         app.detail_box.cget("font")

--- a/gui/sidebar.py
+++ b/gui/sidebar.py
@@ -1,7 +1,10 @@
 import os
+import os
+
 from . import create_button
 from .style import style, PADDING_Y
 from .dropzone import DropZone
+from helpers import logger
 
 SIDEBAR_LOGO_WIDTH = 200
 
@@ -121,10 +124,7 @@ def build_sidebar(app):
     opp.grid_columnconfigure(1, weight=1)
 
     app.kunde_var = ctk.StringVar(master=app, value="")
-    try:
-        default_user = os.environ.get("USERNAME") or os.environ.get("USER") or ""
-    except Exception:
-        default_user = ""
+    default_user = os.environ.get("USERNAME") or os.environ.get("USER") or ""
     app.utfort_av_var = ctk.StringVar(master=app, value=default_user)
 
     ctk.CTkLabel(opp, text="Kunde", font=style.FONT_BODY).grid(
@@ -221,7 +221,7 @@ def build_sidebar(app):
             pady=(0, PADDING_Y),
             sticky="ew",
         )
-    except Exception:
-        pass
+    except (ImportError, OSError):
+        logger.exception("Kunne ikke laste sidebar-logo")
 
     return card

--- a/helpers.py
+++ b/helpers.py
@@ -118,7 +118,7 @@ def parse_amount(x):
         s = "-" + s[:-1]
     try:
         return float(s)
-    except Exception:
+    except ValueError:
         return None
 
 
@@ -174,7 +174,7 @@ def format_number_with_thousands(s):
         intp = core
     try:
         intp = int(intp)
-    except Exception:
+    except ValueError:
         return s
     int_fmt = f"{intp:,}".replace(",", " ")
     return f"{int_fmt},{dec}" if dec is not None else int_fmt
@@ -273,5 +273,5 @@ def fmt_pct(n):
     """
     try:
         return f"{n:.1f}%"
-    except Exception:
+    except (TypeError, ValueError):
         return ""

--- a/report.py
+++ b/report.py
@@ -2,7 +2,7 @@
 import os
 from datetime import datetime
 from pathlib import Path
-from tkinter import filedialog
+from tkinter import filedialog, TclError
 import webbrowser
 
 from helpers import (
@@ -38,7 +38,8 @@ def create_info_table(app, now):
     try:
         kunde = to_str(app.kunde_var.get()) if hasattr(app, "kunde_var") else ""
         utfort = to_str(app.utfort_av_var.get()) if hasattr(app, "utfort_av_var") else ""
-    except Exception:
+    except TclError:
+        logger.exception("Klarte ikke hente kundedata")
         kunde = utfort = ""
     if kunde:
         info_rows.append(["Kunde", kunde])
@@ -265,9 +266,10 @@ def export_pdf(app):
         app._show_inline(f"Lagret PDF: {os.path.basename(save)}", ok=True)
         try:
             webbrowser.open(Path(save).resolve().as_uri())
-        except Exception as e:  # pragma: no cover - OS-avhengig
+        except (webbrowser.Error, OSError) as e:  # pragma: no cover - OS-avhengig
             logger.error(f"Kunne ikke åpne PDF: {e}")
     except Exception as e:  # pragma: no cover - direkte feil fra reportlab
+        logger.exception("Feil ved PDF-generering")
         app._show_inline(f"Feil ved PDF-generering: {e}", ok=False)
     finally:
         app._set_status("")


### PR DESCRIPTION
## Sammendrag
- Bytt ut generelle `except Exception` med konkrete unntak i hjelpefunksjoner og datalastingsrutiner
- Legg til logging ved feil i GUI-komponenter og rapportgenerering for å bevare feilsøkingsinformasjon
- Forbedre opprydding og ikonhåndtering med tydeligere unntakshåndtering

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c66df4b09c8328a064ddd36b875558