### PR TITLE
Bruk Decimal for beløpshåndtering

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -4,6 +4,8 @@
 import os
 import re
 
+from decimal import Decimal
+
 from .style import style
 from helpers import logger
 from tkinter import TclError
@@ -638,10 +640,9 @@ class App:
     def _update_status_card(self):
         self._ensure_helpers()
         from data_utils import calc_sum_kontrollert, calc_sum_net_all
-
         sum_k = calc_sum_kontrollert(self.sample_df, self.decisions)
         sum_a = calc_sum_net_all(self.df)
-        pct = (sum_k / sum_a * 100.0) if sum_a else 0.0
+        pct = (sum_k / sum_a * Decimal("100")) if sum_a else Decimal("0")
         self.lbl_st_sum_kontrollert.configure(text=f"Sum kontrollert: {fmt_money(sum_k)} kr")
         self.lbl_st_sum_alle.configure(text=f"Sum alle bilag: {fmt_money(sum_a)} kr")
         self.lbl_st_pct.configure(text=f"% kontrollert av sum: {fmt_pct(pct)}")

--- a/gui/ledger.py
+++ b/gui/ledger.py
@@ -1,5 +1,7 @@
 LEDGER_COLS = ["Kontonr", "Konto", "Beskrivelse", "MVA", "MVA-beløp", "Beløp", "Postert av"]
 
+from decimal import Decimal
+
 
 def apply_treeview_theme(app):
     from tkinter import ttk, TclError
@@ -123,7 +125,10 @@ def ledger_rows(app, invoice_value: str):
         kre = parse_amount(r.get(app.gl_credit_col)) if app.gl_credit_col else None
         belop = parse_amount(r.get(app.gl_amount_col)) if app.gl_amount_col else None
         if belop is None and (deb is not None or kre is not None):
-            belop = (deb or 0.0) - (kre or 0.0)
+            belop = (
+                (deb if deb is not None else Decimal("0"))
+                - (kre if kre is not None else Decimal("0"))
+            )
         belop_str = fmt_money(belop)
         postert_av = to_str(r.get(app.gl_postedby_col, ""))
         rows.append({
@@ -181,11 +186,11 @@ def populate_ledger_table(app, invoice_value: str):
         msg = "Ingen hovedbok lastet." if app.gl_df is None else "Ingen bilagslinjer for dette bilagsnummeret."
         app.ledger_sum.configure(text=msg)
         return
-    total = 0.0
+    total = Decimal("0")
     for i, r in enumerate(rows):
         tags = ["even" if i % 2 == 0 else "odd"]
         v = parse_amount(r["Beløp"])
-        total += (v or 0.0)
+        total += (v if v is not None else Decimal("0"))
         app.ledger_tree.insert("", "end", values=[r[c] for c in app.ledger_cols], tags=tags)
     autofit_tree_columns(app.ledger_tree, app.ledger_cols)
     app.ledger_sum.configure(text=f"Sum beløp: {fmt_money(total)}   •   Linjer: {len(rows)}")

--- a/helpers.py
+++ b/helpers.py
@@ -3,6 +3,7 @@ import os
 import re
 import sys
 import logging
+from decimal import Decimal
 
 
 def setup_logger(log_path: str = "logs/bilagskontroll.log") -> logging.Logger:
@@ -103,7 +104,7 @@ def parse_amount(x):
 
     Returnerer
     ----------
-    float | None
+    Decimal | None
         Tallverdi om mulig, ellers ``None``.
     """
     s = to_str(x).replace(" ", "").replace("\xa0", "")
@@ -117,8 +118,8 @@ def parse_amount(x):
     if s.endswith("-") and s[:-1].replace(".", "", 1).isdigit():
         s = "-" + s[:-1]
     try:
-        return float(s)
-    except ValueError:
+        return Decimal(s)
+    except Exception:
         return None
 
 

--- a/report.py
+++ b/report.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from pathlib import Path
 from tkinter import filedialog, TclError
 import webbrowser
+from decimal import Decimal
 
 from helpers import (
     to_str,
@@ -71,7 +72,7 @@ def create_status_table(app, body):
     remaining = sum(1 for d in app.decisions if d is None)
     sum_k = calc_sum_kontrollert(app.sample_df, app.decisions)
     sum_a = calc_sum_net_all(app.df)
-    pct = (sum_k / sum_a * 100.0) if sum_a else 0.0
+    pct = (sum_k / sum_a * Decimal("100")) if sum_a else Decimal("0")
 
     import pandas as pd
     dec_ser = pd.Series(app.decisions).reindex(app.sample_df.index)
@@ -81,7 +82,8 @@ def create_status_table(app, body):
             mask = dec_ser.isna()
         else:
             mask = dec_ser == dec_value
-        return float(app.sample_df.loc[mask, "_netto_float"].sum())
+        vals = app.sample_df.loc[mask, "_netto_float"].dropna().tolist()
+        return sum(vals, Decimal("0"))
 
     sum_approved = _sum_for_decision("Godkjent")
     sum_rejected = _sum_for_decision("Ikke godkjent")

--- a/report_utils.py
+++ b/report_utils.py
@@ -1,5 +1,6 @@
 from helpers import parse_amount, fmt_money
 from gui.ledger import ledger_rows
+from decimal import Decimal
 
 
 def build_ledger_table(app, invoice_value: str, style_small):
@@ -9,10 +10,10 @@ def build_ledger_table(app, invoice_value: str, style_small):
     if not rows:
         return Paragraph("Ingen bokføringslinjer for dette fakturanummeret.", style_small)
     data = [["Kontonr", "Konto", "MVA", "MVA-beløp", "Beløp", "Postert av"]]
-    total = 0.0
+    total = Decimal("0")
     for r in rows:
         v = parse_amount(r["Beløp"])
-        total += v or 0.0
+        total += v if v is not None else Decimal("0")
         data.append([
             r["Kontonr"],
             r["Konto"],

--- a/tests/test_calc_sum_net_all.py
+++ b/tests/test_calc_sum_net_all.py
@@ -1,48 +1,49 @@
 import pandas as pd
+from decimal import Decimal
 from data_utils import calc_sum_net_all
 
 
 def test_calc_sum_net_all_uten_summeringsrad():
     df = pd.DataFrame({
         'tekst': ['rad1', 'rad2', None],
-        'netto': [100.0, 200.0, 0.0]
+        'netto': [Decimal('100'), Decimal('200'), Decimal('0')]
     })
     df['_netto_float'] = df['netto']
-    assert calc_sum_net_all(df) == 300.0
+    assert calc_sum_net_all(df) == Decimal('300')
 
 
 def test_calc_sum_net_all_med_summeringsrader():
     df = pd.DataFrame({
         'tekst': ['rad1', 'Sum', 'rad2', 'SUM'],
-        'netto': [100.0, 999.0, 200.0, 300.0]
+        'netto': [Decimal('100'), Decimal('999'), Decimal('200'), Decimal('300')]
     })
     df['_netto_float'] = df['netto']
-    assert calc_sum_net_all(df) == 300.0
+    assert calc_sum_net_all(df) == Decimal('300')
 
 
 def test_calc_sum_net_all_kun_summeringsrad():
     df = pd.DataFrame({
         'tekst': ['Sum'],
-        'netto': [123.0]
+        'netto': [Decimal('123')]
     })
     df['_netto_float'] = df['netto']
-    assert calc_sum_net_all(df) == 0.0
+    assert calc_sum_net_all(df) == Decimal('0')
 
 
 def test_calc_sum_net_all_beholder_siste_rad_uten_sum():
     df = pd.DataFrame({
         'tekst': ['rad1', 'rad2', 'rad3'],
-        'netto': [100.0, 200.0, 300.0]
+        'netto': [Decimal('100'), Decimal('200'), Decimal('300')]
     })
     df['_netto_float'] = df['netto']
-    assert calc_sum_net_all(df) == 600.0
+    assert calc_sum_net_all(df) == Decimal('600')
 
 
 def test_calc_sum_net_all_med_sum_i_annen_kolonne():
     df = pd.DataFrame({
         'tekst': ['rad1', 'rad2'],
         'kommentar': ['ok', 'sum her'],
-        'netto': [100.0, 200.0]
+        'netto': [Decimal('100'), Decimal('200')]
     })
     df['_netto_float'] = df['netto']
-    assert calc_sum_net_all(df) == 100.0
+    assert calc_sum_net_all(df) == Decimal('100')

--- a/tests/test_parse_amount.py
+++ b/tests/test_parse_amount.py
@@ -1,6 +1,7 @@
+from decimal import Decimal
 from helpers import parse_amount
 
 
 def test_parse_amount_parenteser():
-    assert parse_amount("(123)") == -123.0
-    assert parse_amount("(123,45)") == -123.45
+    assert parse_amount("(123)") == Decimal("-123")
+    assert parse_amount("(123,45)") == Decimal("-123.45")

--- a/tests/test_status_card.py
+++ b/tests/test_status_card.py
@@ -1,4 +1,5 @@
 import pandas as pd
+from decimal import Decimal
 import gui
 from gui import App
 
@@ -16,8 +17,8 @@ class DummyWidget:
 
 class FakeApp:
     def __init__(self):
-        self.df = pd.DataFrame({'Faktura':[1], 'Beløp':[100]})
-        self.df['_netto_float'] = self.df['Beløp'].astype(float)
+        self.df = pd.DataFrame({'Faktura':[1], 'Beløp':[Decimal('100')]})
+        self.df['_netto_float'] = self.df['Beløp']
         self.sample_df = self.df.copy()
         self.idx = 0
         self.invoice_col = 'Faktura'


### PR DESCRIPTION
## Oppsummering
- Endret `parse_amount` til å bruke `Decimal` og oppdaterte formatering av pengebeløp
- Summeringsfunksjoner og rapportbygging bruker nå `Decimal` for mer presis håndtering
- Tilpasset tester og hjelpefunksjoner til `Decimal`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c673297ab883289730a9b7291aa08a