### PR TITLE
Gi ttk.Style-objektet et tydeligere navn i autofit_tree_columns

### DIFF
--- a/gui/ledger.py
+++ b/gui/ledger.py
@@ -143,10 +143,10 @@ def autofit_tree_columns(tree, cols, total_width=None):
     from tkinter import ttk
     from .style import PADDING_X
 
-    style = ttk.Style()
-    font_name = style.lookup(tree.cget("style"), "font") or "TkDefaultFont"
+    ttk_style = ttk.Style()
+    font_name = ttk_style.lookup(tree.cget("style"), "font") or "TkDefaultFont"
     body_font = tkfont.nametofont(font_name)
-    head_font_name = style.lookup(f"{tree.cget('style')}.Heading", "font")
+    head_font_name = ttk_style.lookup(f"{tree.cget('style')}.Heading", "font")
     head_font = tkfont.nametofont(head_font_name) if head_font_name else body_font
 
     widths: list[int] = []


### PR DESCRIPTION
## Sammendrag
- Gi ttk.Style-objektet et mer beskrivende navn for å unngå forveksling med modulnavn

## Testing
- `pytest tests/test_ledger_message.py tests/test_status_card.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6732e552c83288965f297bc01b5e4