### PR TITLE
Fjerner duplisert os-import i sidebar

### DIFF
--- a/gui/sidebar.py
+++ b/gui/sidebar.py
@@ -1,5 +1,4 @@
 import os
-import os
 
 from . import create_button
 from .style import style, PADDING_Y


### PR DESCRIPTION
## Oppsummering
- fjerner dobbelt `import os` øverst i `gui/sidebar.py`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c67a7ed8b08328bafa952d23cf3e4a