### PR TITLE
Forbedre tekstfarge i DropZone ved dra-operasjoner

### DIFF
--- a/gui/dropzone.py
+++ b/gui/dropzone.py
@@ -25,13 +25,15 @@ class DropZone(ctk.CTkFrame):
         self._dnd_border = dnd_border
         self._highlight = highlight
         self.drop_callback = drop_callback
+        self._label_text_color = dnd_border
 
-        ctk.CTkLabel(
+        self.label = ctk.CTkLabel(
             self,
             text=text,
             anchor="center",
-            text_color=dnd_border,
-        ).pack(expand=True, fill="both", padx=style.PAD_MD, pady=style.PAD_SM)
+            text_color=self._label_text_color,
+        )
+        self.label.pack(expand=True, fill="both", padx=style.PAD_MD, pady=style.PAD_SM)
 
         for evt in ("<<DragEnter>>", "<<DropEnter>>"):
             self.dnd_bind(evt, self._on_drag_enter)
@@ -40,9 +42,11 @@ class DropZone(ctk.CTkFrame):
 
     def _on_drag_enter(self, _):
         self.configure(fg_color=self._highlight, border_color=self._highlight)
+        self.label.configure(text_color=style.get_color_pair("fg"))
 
     def reset_colors(self, _=None):
         self.configure(fg_color=self._dnd_bg, border_color=self._dnd_border)
+        self.label.configure(text_color=self._label_text_color)
 
     def on_drop(self, event):
         self.reset_colors()


### PR DESCRIPTION
## Sammendrag
- Lagre CTkLabel-instansen og dens opprinnelige tekstfarge i DropZone.
- Endre `_on_drag_enter` til å oppdatere tekstfargen for bedre kontrast.
- Tilbakestill tekstfargen i `reset_colors` for å gjenopprette utgangspunktet.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c67a91da008328b97090ae3842e8f4