### PR TITLE
Fargemerking av status i hovedvisning

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -740,6 +740,24 @@ class App:
             lines.append(f"{key}: {disp}")
         return "\n".join(lines).strip()
 
+    def _update_status_label(self, status: str | None, placeholder: str = "—"):
+        if not hasattr(self, "lbl_status"):
+            return
+
+        text = status if status else placeholder
+
+        if status == "Godkjent":
+            font = style.FONT_TITLE or style.FONT_TITLE_LITE or style.FONT_BODY
+            color = style.get_color("success")
+        elif status == "Ikke godkjent":
+            font = style.FONT_TITLE or style.FONT_TITLE_LITE or style.FONT_BODY
+            color = style.get_color("error")
+        else:
+            font = style.FONT_TITLE_LITE or style.FONT_BODY
+            color = style.get_color("fg")
+
+        self.lbl_status.configure(text=text, font=font, text_color=color)
+
     def _update_status_card_safe(self):
         try:
             self._update_status_card()
@@ -754,7 +772,7 @@ class App:
             inv_val = to_str(self.sample_df.iloc[self.idx].get(self.invoice_col, "")) if len(self.sample_df)>0 else "—"
             self.lbl_invoice.configure(text=f"Fakturanr: {inv_val or '—'}")
             st = self.decisions[self.idx] if (self.decisions and self.idx < len(self.decisions)) else None
-            self.lbl_status.configure(text=f"Status: {st or '—'}")
+            self._update_status_label(st)
 
             row_dict = self._current_row_dict()
             self.detail_box.configure(state="normal"); self.detail_box.delete("0.0","end")
@@ -778,7 +796,9 @@ class App:
             if self.comments and self.idx < len(self.comments) and self.comments[self.idx]:
                 self.comment_box.insert("0.0", self.comments[self.idx])
         else:
-            self.lbl_count.configure(text="Bilag: –/–"); self.lbl_invoice.configure(text="Fakturanr: –"); self.lbl_status.configure(text="Status: –")
+            self.lbl_count.configure(text="Bilag: –/–")
+            self.lbl_invoice.configure(text="Fakturanr: –")
+            self._update_status_label(None, placeholder="–")
             self.detail_box.configure(state="normal"); self.detail_box.delete("0.0","end"); self.detail_box.insert("0.0","Velg Excel-fil og lag et utvalg."); self.detail_box.configure(state="disabled")
             if hasattr(self, "ledger_tree"):
                 for item in self.ledger_tree.get_children():

--- a/gui/mainview.py
+++ b/gui/mainview.py
@@ -16,10 +16,19 @@ def build_header(app):
     head_font = style.FONT_TITLE_LITE
 
     app.lbl_count = ctk.CTkLabel(head, text="Bilag: –/–", font=style.FONT_TITLE)
-    app.lbl_status = ctk.CTkLabel(head, text="Status: –", font=head_font)
+    status_frame = ctk.CTkFrame(head, fg_color="transparent")
+    status_frame.grid(row=0, column=1, padx=style.PAD_MD, sticky="w")
+    app.lbl_status_label = ctk.CTkLabel(status_frame, text="Status:", font=head_font)
+    app.lbl_status_label.grid(row=0, column=0, padx=(0, style.PAD_XXS))
+    app.lbl_status = ctk.CTkLabel(
+        status_frame,
+        text="–",
+        font=head_font,
+        text_color=style.get_color("fg"),
+    )
+    app.lbl_status.grid(row=0, column=1)
     app.lbl_invoice = ctk.CTkLabel(head, text="Fakturanr: –", font=head_font)
     app.lbl_count.grid(row=0, column=0, padx=(style.PAD_XS, style.PAD_LG))
-    app.lbl_status.grid(row=0, column=1, padx=style.PAD_MD)
     app.lbl_invoice.grid(row=0, column=2, padx=style.PAD_MD)
     create_button(head, text="📋 Kopier fakturanr", command=app.copy_invoice).grid(row=0, column=3, padx=(style.PAD_MD,0))
     app.copy_feedback = ctk.CTkLabel(

--- a/tests/test_ledger_message.py
+++ b/tests/test_ledger_message.py
@@ -46,6 +46,9 @@ class FakeApp:
         return ""
     def _update_status_card_safe(self):
         pass
+    def _update_status_label(self, status, placeholder="—"):
+        text = status if status else placeholder
+        self.lbl_status.configure(text=text)
 
 
 def test_message_when_gl_loaded_but_no_sample():

--- a/tests/test_status_card.py
+++ b/tests/test_status_card.py
@@ -46,6 +46,9 @@ class FakeApp:
         return ""
     def _update_status_card_safe(self):
         self.status_card_called = True
+    def _update_status_label(self, status, placeholder="—"):
+        text = status if status else placeholder
+        self.lbl_status.configure(text=text)
 
 
 def test_status_card_updates_after_sample():


### PR DESCRIPTION
## Sammendrag
- deler statusvisningen i hovedhodet slik at «Status:» og selve verdien kan styles separat
- legger til hjelpefunksjon som viser «Godkjent» i grønn fet tekst og «Ikke godkjent» i rød fet tekst
- oppdaterer test-dummyene slik at de spiller på lag med den nye statusoppdateringen

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68c926ca5e148328b2bf9ab961f90396