### PR TITLE
Oppdater hovedlogo og fjern bunnlogo

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -305,51 +305,43 @@ class App:
         ctk = _ctk()
         from helpers_path import resource_path
         try:
-            dark = ctk.get_appearance_mode().lower() == "dark"
+            ctk.get_appearance_mode()
         except (AttributeError, TclError) as e:
             logger.debug(f"Klarte ikke hente tema: {e}")
-            dark = False
-        ico = "icons/bilagskontroll_icon_darkmode.ico" if dark else "icons/bilagskontroll_logo.ico"
-        png = "icons/bilagskontroll_icon_darkmode_256.png" if dark else "icons/bilagskontroll_logo_256.png"
+        ico = "icons/bilagskontroll_logo_all.ico"
+        ico_path = resource_path(ico)
         try:
-            self.iconbitmap(resource_path(ico))
+            self.iconbitmap(ico_path)
         except (TclError, OSError) as e:
             logger.debug(f"Kunne ikke sette ikon: {e}")
         try:
-            self.app_icon_img = tk.PhotoImage(file=resource_path(png))
+            from PIL import Image, ImageTk
+
+            with Image.open(ico_path) as icon_img:
+                icon_rgba = icon_img.convert("RGBA")
+                self.app_icon_img = ImageTk.PhotoImage(icon_rgba)
             self.iconphoto(False, self.app_icon_img)
+        except ImportError as e:
+            logger.debug(f"Kunne ikke importere PIL for ikon: {e}")
         except (TclError, OSError) as e:
             logger.debug(f"Kunne ikke laste ikonbilde: {e}")
+        except Exception as e:  # pragma: no cover - uventa PIL-feil
+            logger.debug(f"Kunne ikke konvertere ikon: {e}")
 
     def load_logo_images(self):
         ctk = _ctk()
         from helpers_path import resource_path
         try:
             from PIL import Image
-            img_light = Image.open(resource_path("icons/bilagskontroll_logo_256.png"))
+            img = Image.open(resource_path("icons/bilagskontroll_logo_all.ico"))
             try:
-                img_dark = Image.open(resource_path("icons/bilagskontroll_icon_darkmode_256.png"))
-            except OSError:
-                img_dark = None
-            try:
-                if img_dark:
-                    self.logo_img = ctk.CTkImage(light_image=img_light, dark_image=img_dark, size=(32, 32))
-                else:
-                    self.logo_img = ctk.CTkImage(light_image=img_light, size=(32, 32))
+                self.logo_img = ctk.CTkImage(light_image=img, size=(32, 32))
             except TypeError:
-                self.logo_img = ctk.CTkImage(img_light, size=(32, 32))
+                self.logo_img = ctk.CTkImage(img, size=(32, 32))
         except (ImportError, OSError) as e:
             logger.error(f"Kunne ikke laste logo: {e}")
             self.logo_img = None
             return
-        if hasattr(self, "bottom_frame"):
-            ctk.CTkLabel(self.bottom_frame, text="", image=self.logo_img).grid(
-                row=0,
-                column=3,
-                padx=(style.PAD_MD, 0),
-                pady=style.PAD_SM,
-                sticky="e",
-            )
 
     def _on_drop(self, event):
         path = event.data.strip("{}").strip()


### PR DESCRIPTION
## Sammendrag
- erstattet alle bilagskontroll-logoer med den nye `bilagskontroll_logo_all.ico`
- lastet ikon for hovedvinduet via PIL slik at .ico-filen brukes konsekvent
- fjernet visning av logo nederst i hovedvinduet

## Testing
- pytest *(feiler: mangler avhengigheter `pandas` og `openpyxl` i miljøet)*

------
https://chatgpt.com/codex/tasks/task_e_68cae30788d48328be2d53fb2d2b403d