### PR TITLE
Fjern automatisk systemmodus for tema

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -19,6 +19,9 @@ except Exception as e:  # pragma: no cover - valfri innstilling
 # CustomTkinter importeres ved behov for raskere oppstart.
 _ctk_mod = None
 
+# Standard tema som brukes dersom brukeren ikke velger noe annet.
+DEFAULT_APPEARANCE_MODE = "light"
+
 
 def _ctk():
     """Importer ``customtkinter`` ved første kall og returner modulen."""
@@ -273,7 +276,7 @@ class App:
         ctk = _ctk()
         if getattr(self, "_theme_initialized", False):
             return
-        ctk.set_appearance_mode("system")
+        ctk.set_appearance_mode(DEFAULT_APPEARANCE_MODE)
         ctk.set_default_color_theme("blue")
         scale = UI_SCALING or (self.winfo_fpixels("1i") / 96)
         if hasattr(ctk, "set_widget_scaling"):
@@ -289,10 +292,12 @@ class App:
     def _switch_theme(self, mode):
         ctk = _ctk()
         self._init_theme()
-        mode = str(mode).lower()
-        if mode not in {"light", "dark", "system"}:
-            mode = "system"
+        mode = str(mode).strip().lower()
+        if mode not in {"light", "dark"}:
+            mode = DEFAULT_APPEARANCE_MODE
         ctk.set_appearance_mode(mode)
+        if hasattr(self, "theme_var"):
+            self.theme_var.set(mode.title())
         if self._icon_ready:
             self._update_icon()
         from .ledger import apply_treeview_theme, update_treeview_stripes

--- a/gui/mainview.py
+++ b/gui/mainview.py
@@ -1,4 +1,4 @@
-from . import create_button
+from . import DEFAULT_APPEARANCE_MODE, create_button
 from .style import style
 from .style import PADDING_Y
 
@@ -52,15 +52,16 @@ def build_header(app):
         column=7,
         padx=(style.PAD_MD, style.PAD_XS),
     )
-    app.theme_var = ctk.StringVar(value="System")
+    default_theme_label = DEFAULT_APPEARANCE_MODE.title()
+    app.theme_var = ctk.StringVar(value=default_theme_label)
     app.theme_menu = ctk.CTkOptionMenu(
         head,
         variable=app.theme_var,
-        values=["System", "Light", "Dark"],
+        values=["Light", "Dark"],
         command=app._switch_theme,
     )
     app.theme_menu.grid(row=0, column=8, padx=(0, style.PAD_MD))
-    app.theme_menu.set("System")
+    app.theme_menu.set(default_theme_label)
 
     return head
 


### PR DESCRIPTION
## Oppsummering
- sett et fast standardtema i GUI-et slik at CustomTkinter ikke bruker systemdeteksjon
- oppdater temavelgeren til å bare tilby lys og mørk modus med korrekt forhåndsvalg

## Tester
- `pytest` *(feilet: mangler avhengighetene pandas og openpyxl i testmiljøet)*

------
https://chatgpt.com/codex/tasks/task_e_68cae35434c083289f374c6b69ca743b